### PR TITLE
Bluetooth interface

### DIFF
--- a/lib/Package.swift
+++ b/lib/Package.swift
@@ -11,6 +11,8 @@ let package = Package(
     ],
     products: [
         .library(name: "App", targets: ["App"]),
+        .library(name: "Bluetooth", targets: ["Bluetooth"]),
+        .library(name: "BluetoothClient", targets: ["BluetoothClient"]),
         .library(name: "WebView", targets: ["WebView"]),
     ],
     dependencies: [
@@ -23,10 +25,30 @@ let package = Package(
                 "WebView",
             ]
         ),
-        .target(name: "WebView"),
         .testTarget(
             name: "AppTests",
             dependencies: ["App"]
+        ),
+
+        .target(
+            name: "Bluetooth"
+        ),
+        .testTarget(
+            name: "BluetoothTests",
+            dependencies: ["Bluetooth"]
+        ),
+
+        .target(
+            name: "BluetoothClient",
+            dependencies: ["Bluetooth"]
+        ),
+        .testTarget(
+            name: "BluetoothClientTests",
+            dependencies: ["BluetoothClient"]
+        ),
+
+        .target(
+            name: "WebView"
         ),
     ]
 )

--- a/lib/Sources/Bluetooth/Advertisement.swift
+++ b/lib/Sources/Bluetooth/Advertisement.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+public struct Advertisement: Equatable, Sendable {
+    public let peripheralId: UUID
+    public let rssi: Int
+    public let isConnectable: Bool?
+    public let localName: String?
+    public let manufacturerData: ManufacturerData?
+    public let overflowServiceUUIDs: [UUID]
+    public let serviceData: ServiceData
+    public let serviceUUIDs: [UUID]
+    public let solicitedServiceUUIDs: [UUID]
+    public let txPowerLevel: Int?
+
+    public init(
+        peripheralId: UUID,
+        rssi: Int,
+        isConnectable: Bool?,
+        localName: String?,
+        manufacturerData: ManufacturerData?,
+        overflowServiceUUIDs: [UUID],
+        serviceData: ServiceData,
+        serviceUUIDs: [UUID],
+        solicitedServiceUUIDs: [UUID],
+        txPowerLevel: Int?
+    ) {
+        self.peripheralId = peripheralId
+        self.rssi = rssi
+        self.isConnectable = isConnectable
+        self.localName = localName
+        self.manufacturerData = manufacturerData
+        self.overflowServiceUUIDs = overflowServiceUUIDs
+        self.serviceData = serviceData
+        self.serviceUUIDs = serviceUUIDs
+        self.solicitedServiceUUIDs = solicitedServiceUUIDs
+        self.txPowerLevel = txPowerLevel
+    }
+}

--- a/lib/Sources/Bluetooth/AnyEquatable.swift
+++ b/lib/Sources/Bluetooth/AnyEquatable.swift
@@ -1,0 +1,10 @@
+
+func _isEqual(_ lhs: Any, _ rhs: Any) -> Bool? {
+  (lhs as? any Equatable)?.isEqual(other: rhs)
+}
+
+extension Equatable {
+  fileprivate func isEqual(other: Any) -> Bool {
+    self == other as? Self
+  }
+}

--- a/lib/Sources/Bluetooth/AnyPeripheral.swift
+++ b/lib/Sources/Bluetooth/AnyPeripheral.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/**
+ A type-erase peripheral to bridge between the universal and the existential type.
+ */
+@dynamicMemberLookup
+public struct AnyPeripheral: Sendable {
+    private let wrapped: any PeripheralProtocol
+
+    public init(peripheral: some PeripheralProtocol) {
+        wrapped = peripheral
+    }
+
+    public subscript<T>(dynamicMember keyPath: KeyPath<any PeripheralProtocol, T>) -> T {
+        wrapped[keyPath: keyPath]
+    }
+}
+
+extension PeripheralProtocol {
+    public func eraseToAnyPeripheral() -> AnyPeripheral {
+        return AnyPeripheral(peripheral: self)
+    }
+}
+
+extension AnyPeripheral {
+    public func unerase<T: PeripheralProtocol>(as: T.Type) -> T? {
+        return wrapped as? T
+    }
+}
+
+extension AnyPeripheral: Identifiable {
+    public var id: UUID { wrapped.identifier }
+}
+
+extension AnyPeripheral: Equatable {
+    public static func == (lhs: AnyPeripheral, rhs: AnyPeripheral) -> Bool {
+        _isEqual(lhs, rhs) ?? false
+    }
+}

--- a/lib/Sources/Bluetooth/BluetoothError.swift
+++ b/lib/Sources/Bluetooth/BluetoothError.swift
@@ -1,0 +1,19 @@
+
+public enum BluetoothError: Error, Sendable {
+    case CausedBy(any Error)
+    case Unknown
+}
+
+extension BluetoothError: Equatable {
+    public static func == (lhs: BluetoothError, rhs: BluetoothError) -> Bool {
+        switch (lhs, rhs) {
+        case let (.CausedBy(lhsError), .CausedBy(rhsError)):
+            // This only makes sense because the underlying NSErrors are equatable
+            _isEqual(lhsError, rhsError) ?? false
+        case (.Unknown, .Unknown):
+            true
+        default:
+            false
+        }
+    }
+}

--- a/lib/Sources/Bluetooth/Characteristic.swift
+++ b/lib/Sources/Bluetooth/Characteristic.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/**
+ Shadows CBCharacteristic
+ */
+public struct Characteristic: Equatable, Sendable {
+    public let uuid: UUID
+    public let properties: CharacteristicProperties
+    public let value: Data?
+    public let descriptors: [Descriptor]
+    public let isNotifying: Bool
+}

--- a/lib/Sources/Bluetooth/CharacteristicDiscoveryFilter.swift
+++ b/lib/Sources/Bluetooth/CharacteristicDiscoveryFilter.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct CharacteristicDiscoveryFilter: Sendable {
+    public let service: UUID
+    public let characteristics: [UUID]?
+
+    init(service: UUID, characteristics: [UUID]?) {
+        self.service = service
+        self.characteristics = characteristics
+    }
+}

--- a/lib/Sources/Bluetooth/CharacteristicProperties.swift
+++ b/lib/Sources/Bluetooth/CharacteristicProperties.swift
@@ -1,0 +1,23 @@
+
+/**
+ Shadows CBCharacteristicProperties
+ */
+public struct CharacteristicProperties : OptionSet, Equatable, Sendable {
+
+    public let rawValue: UInt
+
+    public static let broadcast = CharacteristicProperties(rawValue: 1 << 0)
+    public static let read = CharacteristicProperties(rawValue: 1 << 1)
+    public static let writeWithoutResponse = CharacteristicProperties(rawValue: 1 << 2)
+    public static let write = CharacteristicProperties(rawValue: 1 << 3)
+    public static let notify = CharacteristicProperties(rawValue: 1 << 4)
+    public static let indicate = CharacteristicProperties(rawValue: 1 << 5)
+    public static let authenticatedSignedWrites = CharacteristicProperties(rawValue: 1 << 6)
+    public static let extendedProperties = CharacteristicProperties(rawValue: 1 << 7)
+    public static let notifyEncryptionRequired = CharacteristicProperties(rawValue: 1 << 8)
+    public static let indicateEncryptionRequired = CharacteristicProperties(rawValue: 1 << 9)
+
+    public init(rawValue: UInt) {
+        self.rawValue = rawValue
+    }
+}

--- a/lib/Sources/Bluetooth/ConnectionState.swift
+++ b/lib/Sources/Bluetooth/ConnectionState.swift
@@ -1,0 +1,12 @@
+
+/**
+ Shadows CBPeripheralState.
+ */
+public enum ConnectionState: Equatable, Sendable {
+    case connected
+    case disconnected
+    // Do we need these to fulfil the Web APIs?
+    // case connecting
+    // case disconnecting
+    // case unknown
+}

--- a/lib/Sources/Bluetooth/DelegateEvent.swift
+++ b/lib/Sources/Bluetooth/DelegateEvent.swift
@@ -1,0 +1,13 @@
+
+/**
+ Models the various CoreBluetooth delegate events as Sendable data.
+ */
+public enum DelegateEvent: Equatable, Sendable {
+    case systemState(SystemState)
+    case advertisement(AnyPeripheral, Advertisement)
+    case connected(AnyPeripheral)
+    case disconnected(AnyPeripheral, BluetoothError?)
+    case discoveredServices(AnyPeripheral, BluetoothError?)
+    case discoveredCharacteristics(AnyPeripheral, Service, BluetoothError?)
+    case updatedCharacteristic(AnyPeripheral, Characteristic, BluetoothError?)
+}

--- a/lib/Sources/Bluetooth/Descriptor.swift
+++ b/lib/Sources/Bluetooth/Descriptor.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/**
+ Shadows CBDescriptor
+ */
+public struct Descriptor: Equatable, Sendable {
+    public let uuid: UUID
+    public let value: Value
+
+    public enum Value: Equatable, Sendable {
+        case number(NSNumber)
+        case string(String)
+        case data(Data)
+    }
+}
+

--- a/lib/Sources/Bluetooth/Filter.swift
+++ b/lib/Sources/Bluetooth/Filter.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public struct Filter: Sendable {
+    public let services: [UUID]
+    // TODO: filter options
+
+    init(services: [UUID]) {
+        self.services = services
+    }
+}

--- a/lib/Sources/Bluetooth/ManufacturerData.swift
+++ b/lib/Sources/Bluetooth/ManufacturerData.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public struct ManufacturerData: Equatable, Sendable {
+    public let code: UInt16
+    public let data: Data
+
+    public init(code: UInt16, data: Data) {
+        self.code = code
+        self.data = data
+    }
+}
+
+extension ManufacturerData {
+    static func parse(from rawData: Data) -> Self? {
+        guard rawData.count >= 2 else { return nil }
+        let code = rawData.withUnsafeBytes { bytes in
+            UInt16(littleEndian: bytes.load(as: UInt16.self))
+        }
+        return .init(code: code, data: rawData.dropFirst(2))
+    }
+}
+
+extension ManufacturerData: CustomStringConvertible {
+    public var description: String {
+        let codeAsString = String(format: "0x%04X", code)
+        let dataAsString = data.map { String(format: "%02X", $0) }.joined(separator: " ")
+        return "ManufacturerData(Code=\(codeAsString), Data=[\(dataAsString)])"
+    }
+}

--- a/lib/Sources/Bluetooth/PeripheralProtocol.swift
+++ b/lib/Sources/Bluetooth/PeripheralProtocol.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/**
+ A protocol to shadow the system CBPeripheral type.
+ The primary reason this exists is because CBPeripheral has no initializers which makes
+ it impossible to write any kind of test or mock data for UI previews.
+ */
+public protocol PeripheralProtocol: Equatable, Sendable {
+    var identifier: UUID { get }
+    var connectionState: ConnectionState { get }
+    var name: String? { get }
+}

--- a/lib/Sources/Bluetooth/Service.swift
+++ b/lib/Sources/Bluetooth/Service.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/**
+ Shadows CBService
+ */
+public struct Service: Equatable, Sendable {
+    let uuid: UUID
+    let isPrimary: Bool
+    let includedServices: [Service]
+}

--- a/lib/Sources/Bluetooth/ServiceData.swift
+++ b/lib/Sources/Bluetooth/ServiceData.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public struct ServiceData: Equatable, Sendable {
+    private let rawData: [UUID:Data]
+
+    public init(_ rawData: [UUID:Data]) {
+        self.rawData = rawData
+    }
+
+    public func data(for uuid: UUID) -> Data? {
+        return rawData[uuid]
+    }
+}
+
+extension ServiceData: CustomStringConvertible {
+    public var description: String {
+        return "[" + rawData.map { uuid, data in
+            let dataAsString = data.map { String(format: "%02X", $0) }.joined(separator: " ")
+            return "ServiceData(UUID=\(uuid), Data=[\(dataAsString)])"
+        }.joined(separator: ", ") + "]"
+    }
+}

--- a/lib/Sources/Bluetooth/ServiceDiscoveryFilter.swift
+++ b/lib/Sources/Bluetooth/ServiceDiscoveryFilter.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct ServiceDiscoveryFilter: Sendable {
+    public let primaryOnly: Bool
+    public let services: [UUID]?
+
+    init(primaryOnly: Bool, services: [UUID]?) {
+        self.primaryOnly = primaryOnly
+        self.services = services
+    }
+}

--- a/lib/Sources/Bluetooth/SystemState.swift
+++ b/lib/Sources/Bluetooth/SystemState.swift
@@ -1,0 +1,12 @@
+
+/**
+ Shadows CBManagerState.
+ */
+public enum SystemState: Equatable, Sendable {
+    case unknown
+    case resetting
+    case unsupported
+    case unauthorized
+    case poweredOff
+    case poweredOn
+}

--- a/lib/Sources/BluetoothClient/BluetoothClient.swift
+++ b/lib/Sources/BluetoothClient/BluetoothClient.swift
@@ -1,0 +1,13 @@
+
+public struct BluetoothClient: Sendable {
+    public let request: RequestClient
+    public let response: ResponseClient
+
+    public init(
+        request: RequestClient,
+        response: ResponseClient
+    ) {
+        self.request = request
+        self.response = response
+    }
+}

--- a/lib/Sources/BluetoothClient/RequestClient.swift
+++ b/lib/Sources/BluetoothClient/RequestClient.swift
@@ -1,0 +1,50 @@
+import Bluetooth
+import Foundation
+
+public struct RequestClient: Sendable {
+    public var enable: @Sendable () -> SystemState
+    public var disable: @Sendable () -> Void
+    public var state: @Sendable () -> AsyncStream<SystemState>
+    public var scan: @Sendable (Filter) -> AsyncStream<Advertisement>
+    public var scannedPeripheral: @Sendable (UUID) -> AnyPeripheral?
+    public var connect: @Sendable (AnyPeripheral) -> Void
+    public var disconnect: @Sendable (AnyPeripheral) -> Void
+    public var discoverServices: @Sendable (AnyPeripheral, ServiceDiscoveryFilter) -> Void
+    public var discoverCharacteristics: @Sendable (AnyPeripheral, CharacteristicDiscoveryFilter) -> Void
+
+    public init(
+        enable: @Sendable @escaping () -> SystemState,
+        disable: @Sendable @escaping () -> Void,
+        state: @Sendable @escaping () -> AsyncStream<SystemState>,
+        scan: @Sendable @escaping (Filter) -> AsyncStream<Advertisement>,
+        scannedPeripheral: @Sendable @escaping (UUID) -> AnyPeripheral?,
+        connect: @Sendable @escaping (AnyPeripheral) -> Void,
+        disconnect: @Sendable @escaping (AnyPeripheral) -> Void,
+        discoverServices: @Sendable @escaping (AnyPeripheral, ServiceDiscoveryFilter) -> Void,
+        discoverCharacteristics: @Sendable @escaping (AnyPeripheral, CharacteristicDiscoveryFilter) -> Void
+    ) {
+        self.enable = enable
+        self.disable = disable
+        self.state = state
+        self.scan = scan
+        self.scannedPeripheral = scannedPeripheral
+        self.connect = connect
+        self.disconnect = disconnect
+        self.discoverServices = discoverServices
+        self.discoverCharacteristics = discoverCharacteristics
+    }
+}
+
+extension RequestClient {
+    public static let testValue = RequestClient(
+        enable: { fatalError("Not implemented") },
+        disable: { fatalError("Not implemented") },
+        state: { fatalError("Not implemented") },
+        scan: { _ in fatalError("Not implemented") },
+        scannedPeripheral: { _ in fatalError("Not implemented") },
+        connect: { _ in fatalError("Not implemented") },
+        disconnect: { _ in fatalError("Not implemented") },
+        discoverServices: { _, _ in fatalError("Not implemented") },
+        discoverCharacteristics: { _, _ in fatalError("Not implemented") }
+    )
+}

--- a/lib/Sources/BluetoothClient/ResponseClient.swift
+++ b/lib/Sources/BluetoothClient/ResponseClient.swift
@@ -1,0 +1,18 @@
+import Bluetooth
+import Foundation
+
+public struct ResponseClient: Sendable {
+    public var events: AsyncStream<DelegateEvent>
+
+    public init(events: AsyncStream<DelegateEvent>) {
+        self.events = events
+    }
+}
+
+extension ResponseClient {
+    public static let testValue = ResponseClient(
+        events: AsyncStream { _ in
+            fatalError("Not implemented")
+        }
+    )
+}

--- a/lib/Tests/BluetoothClientTests/BluetoothClientTests.swift
+++ b/lib/Tests/BluetoothClientTests/BluetoothClientTests.swift
@@ -1,0 +1,6 @@
+import Testing
+@testable import BluetoothClient
+
+@Test func example() async throws {
+    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+}

--- a/lib/Tests/BluetoothTests/BluetoothTests.swift
+++ b/lib/Tests/BluetoothTests/BluetoothTests.swift
@@ -1,0 +1,6 @@
+import Testing
+@testable import Bluetooth
+
+@Test func example() async throws {
+    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+}


### PR DESCRIPTION
Two new modules:
- Bluetooth: dependency-free interface and data models all `Sendable` (for concurrency) and `Equatable` (for observables)
- BluetoothClient: injectable consumer API that shims the underlying dependency. 

Includes a `testValue` that throws unimplemented errors - when you write a test you use this and override any endpoints consumed in the test.

Plan is for future PRs to create a `mockValue` for injecting ad-hoc implementations into previews/simulator, and a `liveValue` that wil bridge through to, and depend on, `CoreBluetooth` for production/on-device builds.

This pattern of modelling dependencies may seem foreign/strange here in isolation, but it should start to make sense when we stitch things together.
