### PR TITLE
Fix Info.plist tooling

### DIFF
--- a/Topaz/Info.plist
+++ b/Topaz/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Allow web pages opened in Topaz to find and connect to your Bluetooth devices.</string>
+</dict>
+</plist>

--- a/topaz.xcodeproj/project.pbxproj
+++ b/topaz.xcodeproj/project.pbxproj
@@ -35,9 +35,22 @@
 		0BB6F0A72CB496CA003C34A1 /* topazUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = topazUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		0BFDB76A2CCB2668003E0F8D /* Exceptions for "Topaz" folder in "topaz" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 0BB6F08C2CB496C9003C34A1 /* topaz */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		0BB6F08F2CB496C9003C34A1 /* Topaz */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				0BFDB76A2CCB2668003E0F8D /* Exceptions for "Topaz" folder in "topaz" target */,
+			);
 			path = Topaz;
 			sourceTree = "<group>";
 		};
@@ -416,11 +429,12 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"topaz/Preview Content\"";
 				DEVELOPMENT_TEAM = 5EH8QG4538;
+				DONT_GENERATE_INFOPLIST_FILE = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = topaz/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Topaz;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
-				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "Allow web pages opened in Topaz to find and connect to your Bluetooth devices.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -449,11 +463,12 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"topaz/Preview Content\"";
 				DEVELOPMENT_TEAM = 5EH8QG4538;
+				DONT_GENERATE_INFOPLIST_FILE = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = topaz/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Topaz;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
-				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "Allow web pages opened in Topaz to find and connect to your Bluetooth devices.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;


### PR DESCRIPTION
_This was absolutly infuriating_

I was trying to add the fonts to the plist but kept getting "duplicate Info.plist" build errors. I had the same issue when adding the BLE message but ending up editing the project manually to get it working at the time and defering this fix.

Turns out, we need `GENERATE_INFOPLIST_FILE` to be enabled (it is by default), which instructs Xcode to blend in the build settings appropriately for the bundle. This is critical because the debug vs release have differences. By default there is no Info.plist and it is fully generated synthetically.

However, if you add customizations, Xcode creates a concrete Info.plist to store your changes, which it is then supposed to blend with the sythensized stuff. This appears to be broken in a fresh project in Xcode 16, because it subsequently gets "duplicate Info.plist" errors.

To fix it, we have to have `DONT_GENERATE_INFOPLIST_FILE` enabled. And I've not even being sarcastic, we now have `GENERATE_INFOPLIST_FILE=YES` and `DONT_GENERATE_INFOPLIST_FILE=YES` side-by-side in the build settings. It is subtle (insane?) but appears to be the correct combination from what I can glean from the docs [here](https://developer.apple.com/documentation/xcode/build-settings-reference#Dont-Force-Infoplist-Generation) and [here](https://developer.apple.com/documentation/xcode/build-settings-reference#Generate-Infoplist-File).

In any case, it works fine now, and when you edit the project Info in Xcode it will put anything non-standard in the concrete `Info.plist` file and not inside the `project.pbxproj` file. I re-did things from scratch with `DONT_GENERATE_INFOPLIST_FILE` enabled and so now our custom BLE message is moved to that file.
