### PR TITLE
Integrate data payloads

### DIFF
--- a/lib/Javascript/src/Data.ts
+++ b/lib/Javascript/src/Data.ts
@@ -1,0 +1,20 @@
+
+// Converts Uint8Array to base64 string
+export const uint8ArrayToBase64 = (uint8array: Uint8Array): string => {
+    return btoa(String.fromCharCode(...uint8array));
+}
+
+// Converts base64 string to Uint8Array
+export const base64ToUint8Array = (base64: string): Uint8Array => {
+    return Uint8Array.from(atob(base64), (m) => m.codePointAt(0))
+}
+
+// Converts ArrayBuffer to base64 string
+export const arrayBufferToBase64 = (buffer: ArrayBuffer): string => {
+    return uint8ArrayToBase64(new Uint8Array(buffer));
+}
+
+// Converts base64 string to DataView
+export const base64ToDataView = (base64: string): DataView => {
+    return new DataView(base64ToUint8Array(base64).buffer);
+}

--- a/lib/Javascript/src/EventSink.ts
+++ b/lib/Javascript/src/EventSink.ts
@@ -7,7 +7,7 @@ export type TargetedEvent = {
     data?: any;
 }
 
-export function sendEvent(event: TargetedEvent) {
+export function dispatchEvent(event: TargetedEvent) {
     // TODO: find out if we need to support other event types
     const valueEvent = new ValueEvent(event.name, { value: event.data });
     mainDispatcher.postMessage(event.id, valueEvent);

--- a/lib/Javascript/src/Topaz.ts
+++ b/lib/Javascript/src/Topaz.ts
@@ -1,5 +1,5 @@
 import { Bluetooth } from "./Bluetooth";
-import { sendEvent, TargetedEvent } from "./EventSink";
+import { dispatchEvent, TargetedEvent } from "./EventSink";
 
 export class Topaz {
     bluetooth: Bluetooth;
@@ -9,6 +9,6 @@ export class Topaz {
     }
 
     sendEvent = (event: TargetedEvent) => {
-        sendEvent(event);
+        dispatchEvent(event);
     }
 }

--- a/lib/Sources/JsMessage/JsConvertable.swift
+++ b/lib/Sources/JsMessage/JsConvertable.swift
@@ -61,6 +61,12 @@ extension Dictionary: JsConvertable where Key == String, Value == JsConvertable 
     }
 }
 
+extension Data: JsConvertable {
+    public var jsValue: Any {
+        base64EncodedString() as NSString
+    }
+}
+
 private struct JsNull: JsConvertable {
     var jsValue: Any { NSNull() }
 }

--- a/lib/Sources/JsMessage/JsType.swift
+++ b/lib/Sources/JsMessage/JsType.swift
@@ -89,4 +89,8 @@ extension JsType {
         guard case let .dictionary(value) = self else { return .none }
         return value
     }
+
+    public var data: Data? {
+        string.flatMap { Data(base64Encoded: $0) }
+    }
 }


### PR DESCRIPTION
Adds bridging for `Data`/`NSData` within Javascript messages via [base64 translation](https://developer.mozilla.org/en-US/docs/Glossary/Base64#javascript_support). We will need this for any of the API that needs to send or receive binary data as there is no built-in data bridging type. 

Also disambiguated `EventSink.sendEvent` from `Topaz.sendEvent`. Not strictly necessary but helps avoid any confusion. 

Note that nothing the rename has no effect, and the data is not yet used anywhere, so there is no change in the compiled javascript artifact.