### PR TITLE
Have `lint`, `build` and `test` CI jobs run independently of each other

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: make -C lib build
+  test:
+    name: Test
+    runs-on: [self-hosted, ConX, macOS]
+    steps:
+      - uses: actions/checkout@v3
       - run: make -C lib test


### PR DESCRIPTION
> [!NOTE]
> I'll update branch protections once approved.