### PR TITLE
CA-3842 Propagate delegate errors

### DIFF
--- a/lib/Sources/Bluetooth/BluetoothError.swift
+++ b/lib/Sources/Bluetooth/BluetoothError.swift
@@ -1,37 +1,25 @@
 import Foundation
 
 public enum BluetoothError: Error, Sendable {
+    case cancelled
     case causedBy(any Error)
     case noSuchDevice(UUID)
+    case noSuchService(UUID)
     case unavailable
     case unknown
-}
-
-extension BluetoothError: Equatable {
-    public static func == (lhs: BluetoothError, rhs: BluetoothError) -> Bool {
-        switch (lhs, rhs) {
-        case let (.causedBy(lhsError), .causedBy(rhsError)):
-            // This only makes sense because the underlying NSErrors are equatable
-            _isEqual(lhsError, rhsError) ?? false
-        case let (.noSuchDevice(lhsUuid), .noSuchDevice(rhsUuid)):
-            lhsUuid == rhsUuid
-        case (.unavailable, .unavailable):
-            true
-        case (.unknown, .unknown):
-            true
-        default:
-            false
-        }
-    }
 }
 
 extension BluetoothError: LocalizedError {
     public var errorDescription: String? {
         switch self {
+        case .cancelled:
+            "The operation was cancelled"
         case let .causedBy(error):
             error.localizedDescription
         case let .noSuchDevice(uuid):
             "No such device \(uuid.uuidString)"
+        case let .noSuchService(uuid):
+            "No such service \(uuid.uuidString)"
         case .unavailable:
             "Bluetooth not available"
         case .unknown:

--- a/lib/Sources/Bluetooth/DelegateEvent.swift
+++ b/lib/Sources/Bluetooth/DelegateEvent.swift
@@ -6,8 +6,22 @@ public enum DelegateEvent: Equatable, Sendable {
     case systemState(SystemState)
     case advertisement(AnyPeripheral, Advertisement)
     case connected(AnyPeripheral)
-    case disconnected(AnyPeripheral, BluetoothError?)
-    case discoveredServices(AnyPeripheral, BluetoothError?)
-    case discoveredCharacteristics(AnyPeripheral, Service, BluetoothError?)
-    case updatedCharacteristic(AnyPeripheral, Characteristic, BluetoothError?)
+    case disconnected(AnyPeripheral, DelegateEventError?)
+    case discoveredServices(AnyPeripheral, DelegateEventError?)
+    case discoveredCharacteristics(AnyPeripheral, Service, DelegateEventError?)
+    case updatedCharacteristic(AnyPeripheral, Characteristic, DelegateEventError?)
+}
+
+public enum DelegateEventError: Error, Sendable {
+    case causedBy(any Error)
+}
+
+extension DelegateEventError: Equatable {
+    public static func == (lhs: DelegateEventError, rhs: DelegateEventError) -> Bool {
+        switch (lhs, rhs) {
+        case let (.causedBy(lhsError), .causedBy(rhsError)):
+            // This only makes sense because the underlying NSErrors are equatable
+            _isEqual(lhsError, rhsError) ?? false
+        }
+    }
 }

--- a/lib/Sources/BluetoothClient/Errors.swift
+++ b/lib/Sources/BluetoothClient/Errors.swift
@@ -4,10 +4,20 @@ import JsMessage
 extension BluetoothError: DomErrorConvertable {
     public var domErrorName: DomErrorName {
         switch self {
+        case .cancelled: .abort
         case .causedBy: .unknown
         case .noSuchDevice: .notFound
+        case .noSuchService: .notFound
         case .unavailable: .unknown
         case .unknown: .unknown
+        }
+    }
+}
+
+extension DelegateEventError: DomErrorConvertable {
+    public var domErrorName: DomErrorName {
+        switch self {
+        case .causedBy: .operataion
         }
     }
 }

--- a/lib/Sources/BluetoothNative/RelayDelegate.swift
+++ b/lib/Sources/BluetoothNative/RelayDelegate.swift
@@ -27,29 +27,29 @@ class RelayDelegate: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate {
 
     func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: (any Error)?) {
         peripheral.delegate = nil
-        handleEvent(.disconnected(peripheral.eraseToAnyPeripheral(), error.toBluetoothError()))
+        handleEvent(.disconnected(peripheral.eraseToAnyPeripheral(), error.toDelegateError()))
     }
 
     // MARK: - CBPeripheralDelegate
 
     func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: (any Error)?) {
-        handleEvent(.discoveredServices(peripheral.eraseToAnyPeripheral(), error.toBluetoothError()))
+        handleEvent(.discoveredServices(peripheral.eraseToAnyPeripheral(), error.toDelegateError()))
     }
 
     func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: (any Error)?) {
         guard let service = service.toService() else { return }
-        handleEvent(.discoveredCharacteristics(peripheral.eraseToAnyPeripheral(), service, error.toBluetoothError()))
+        handleEvent(.discoveredCharacteristics(peripheral.eraseToAnyPeripheral(), service, error.toDelegateError()))
     }
 
     func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: (any Error)?) {
         guard let characteristic = characteristic.toCharacteristic() else { return }
-        handleEvent(.updatedCharacteristic(peripheral.eraseToAnyPeripheral(), characteristic, error.toBluetoothError()))
+        handleEvent(.updatedCharacteristic(peripheral.eraseToAnyPeripheral(), characteristic, error.toDelegateError()))
     }
 }
 
 fileprivate extension Optional where Wrapped == Error {
-    func toBluetoothError() -> BluetoothError {
-        map(BluetoothError.causedBy) ?? BluetoothError.unknown
+    func toDelegateError() -> DelegateEventError? {
+        map(DelegateEventError.causedBy)
     }
 }
 

--- a/lib/Sources/JsMessage/DomErrorName.swift
+++ b/lib/Sources/JsMessage/DomErrorName.swift
@@ -1,7 +1,9 @@
 
 /// https://webidl.spec.whatwg.org/#idl-DOMException-error-names
 public enum DomErrorName: String, Sendable, Encodable {
-    case unknown = "UnknownError"
-    case notFound = "NotFoundError"
+    case abort = "AbortError"
     case encoding = "EncodingError"
+    case notFound = "NotFoundError"
+    case operataion = "OperationError"
+    case unknown = "UnknownError"
 }


### PR DESCRIPTION
Builds on #22 to take errors that originate from the Core Bluetooth delegate callback an thread them through to the Js promise rejection.

Biggest difference is to allow simultaneous promises for the same resource. AFAICT the following is a valid example use case that would expect to resolve multiple in-flight promises at once:
```javascript
function doubleConnect(gattServer) {
  const c1 = gattServer.connect();
  const c2 = gattServer.connect();
  Promise.all([c1, c2]).then(() => {
    console.log('did connect'); // <-- expected to appear twice upon successful connection
  });
}
```

### Changes

- refactored `PendingAction` from a semaphore to a continuation so we can thread through a value/error result
- refactored `PromiseRegistry` to support multiple promises for the same action and resource 
- created specialized `DelegateEventError` so we can remove the `Equatable` requirement from the generalized`BluetoothError`
- moved the `discoverServices` inline DOM error down onto the messaging serialization layer