### PR TITLE
Remove internal UUID dependency from fake peripheral

### DIFF
--- a/lib/Sources/Bluetooth/FakePeripheral.swift
+++ b/lib/Sources/Bluetooth/FakePeripheral.swift
@@ -11,13 +11,13 @@ public struct FakePeripheral: Equatable, WrappedPeripheral {
 
     public init(
         name: String,
+        identifier: UUID,
         connectionState: ConnectionState = .disconnected,
-        identifier: UUID? = nil,
         services: [Service] = []
     ) {
         self._name = name
+        self._identifier = identifier
         self._connectionState = connectionState
-        self._identifier = identifier ?? UUID()
         self._services = services
     }
 }

--- a/lib/Sources/DevicePicker/MockAdvertisements.swift
+++ b/lib/Sources/DevicePicker/MockAdvertisements.swift
@@ -13,7 +13,7 @@ extension DeviceSelector {
             "35fc49b",
             "Really smart window",
             "Even smarter light bulb",
-        ].map { FakePeripheral(name: $0) }
+        ].map { FakePeripheral(name: $0, identifier: UUID()) }
         return Task {
             while !Task.isCancelled {
                 let delay = UInt64.random(in: 1..<6)

--- a/lib/Tests/BluetoothClientTests/BluetoothEngineTests.swift
+++ b/lib/Tests/BluetoothClientTests/BluetoothEngineTests.swift
@@ -93,7 +93,7 @@ struct BluetoothEngineTests {
 
     @Test
     func disconnect() async throws {
-        let fake = FakePeripheral(name: "bob", connectionState: .connected, identifier: zeroUuid)
+        let fake = FakePeripheral(name: "bob", identifier: zeroUuid, connectionState: .connected)
         let disconnectRequestBody: [String: JsType] = [
             "data": .dictionary([
                 "uuid": .string(fake._identifier.uuidString),
@@ -127,7 +127,7 @@ struct BluetoothEngineTests {
         let expectedServices: [Service] = [
             Service(uuid: UUID(uuidString: "00000003-0000-0000-0000-000000000000")!, isPrimary: true)
         ]
-        let fake = FakePeripheral(name: "bob", connectionState: .connected, identifier: zeroUuid, services: expectedServices)
+        let fake = FakePeripheral(name: "bob", identifier: zeroUuid, connectionState: .connected, services: expectedServices)
         let requestBody: [String: JsType] = [
             "data": .dictionary([
                 "single": .number(true),
@@ -164,7 +164,7 @@ struct BluetoothEngineTests {
             Service(uuid: UUID(uuidString: "00000001-0000-0000-0000-000000000000")!, isPrimary: true),
             Service(uuid: UUID(uuidString: "00000003-0000-0000-0000-000000000000")!, isPrimary: true),
         ]
-        let fake = FakePeripheral(name: "bob", connectionState: .connected, identifier: zeroUuid, services: expectedServices)
+        let fake = FakePeripheral(name: "bob", identifier: zeroUuid, connectionState: .connected, services: expectedServices)
         let requestBody: [String: JsType] = [
             "data": .dictionary([
                 "single": .number(false),
@@ -199,7 +199,7 @@ struct BluetoothEngineTests {
         let expectedServices: [Service] = [
             Service(uuid: UUID(uuidString: "00000003-0000-0000-0000-000000000000")!, isPrimary: true)
         ]
-        let fake = FakePeripheral(name: "bob", connectionState: .connected, identifier: zeroUuid, services: expectedServices)
+        let fake = FakePeripheral(name: "bob", identifier: zeroUuid, connectionState: .connected, services: expectedServices)
         let requestBody: [String: JsType] = [
             "data": .dictionary([
                 "single": .number(false),

--- a/lib/Tests/BluetoothClientTests/DiscoverCharacteristicsTests.swift
+++ b/lib/Tests/BluetoothClientTests/DiscoverCharacteristicsTests.swift
@@ -21,7 +21,7 @@ struct DiscoverCharacteristicsTests {
         let fakeServices: [Service] = [
             Service(uuid: UUID(uuidString: "00000003-0000-0000-0000-000000000000")!, isPrimary: true, characteristics: expectedCharacteristics),
         ]
-        let fake = FakePeripheral(name: "bob", connectionState: .connected, identifier: zeroUuid, services: fakeServices)
+        let fake = FakePeripheral(name: "bob", identifier: zeroUuid, connectionState: .connected, services: fakeServices)
         let requestBody: [String: JsType] = [
             "data": .dictionary([
                 "single": .number(true),
@@ -63,7 +63,7 @@ struct DiscoverCharacteristicsTests {
             Service(uuid: UUID(uuidString: "00000001-0000-0000-0000-000000000000")!, isPrimary: true),
             Service(uuid: UUID(uuidString: "00000003-0000-0000-0000-000000000000")!, isPrimary: true, characteristics: expectedCharacteristics),
         ]
-        let fake = FakePeripheral(name: "bob", connectionState: .connected, identifier: zeroUuid, services: fakeServices)
+        let fake = FakePeripheral(name: "bob", identifier: zeroUuid, connectionState: .connected, services: fakeServices)
         let requestBody: [String: JsType] = [
             "data": .dictionary([
                 "single": .number(false),
@@ -103,7 +103,7 @@ struct DiscoverCharacteristicsTests {
             Service(uuid: UUID(uuidString: "00000001-0000-0000-0000-000000000000")!, isPrimary: true),
             Service(uuid: UUID(uuidString: "00000003-0000-0000-0000-000000000000")!, isPrimary: true, characteristics: expectedCharacteristics),
         ]
-        let fake = FakePeripheral(name: "bob", connectionState: .connected, identifier: zeroUuid, services: fakeServices)
+        let fake = FakePeripheral(name: "bob", identifier: zeroUuid, connectionState: .connected, services: fakeServices)
         let requestBody: [String: JsType] = [
             "data": .dictionary([
                 "single": .number(false),

--- a/lib/Tests/DevicePickerTests/DevicePickerTests.swift
+++ b/lib/Tests/DevicePickerTests/DevicePickerTests.swift
@@ -66,7 +66,7 @@ struct DevicePickerTests {
         let sut = DeviceSelector()
         async let pendingResult = await sut.awaitSelection()
         await Task.yield()
-        let fake = FakePeripheral(name: "bob")
+        let fake = FakePeripheral(name: "bob", identifier: zeroUuid)
         sut.showAdvertisement(peripheral: fake.eraseToAnyPeripheral(), advertisement: fake.fakeAd(rssi: 0))
         await Task.yield()
         sut.makeSelection(fake._identifier)
@@ -84,7 +84,7 @@ struct DevicePickerTests {
         let sut = DeviceSelector()
         async let pendingResult = await sut.awaitSelection()
         await Task.yield()
-        let fake = FakePeripheral(name: "bob")
+        let fake = FakePeripheral(name: "bob", identifier: zeroUuid)
         sut.showAdvertisement(peripheral: fake.eraseToAnyPeripheral(), advertisement: fake.fakeAd(rssi: 0))
         await Task.yield()
         async let collected = await sut.advertisements.first(where: { !$0.isEmpty })!


### PR DESCRIPTION
First of many DI cleanup tickets. This one to just remove the internal dependency on `UUID.init()` from the `FakePeripheral` so that callers can control the UUID value.

Most of the noise is due to re-ordering the initializer parameters.