### PR TITLE
Launch screen background color

### DIFF
--- a/Topaz/Assets.xcassets/LaunchBackground.colorset/Contents.json
+++ b/Topaz/Assets.xcassets/LaunchBackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB1",
+          "green" : "0x4D",
+          "red" : "0x31"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB1",
+          "green" : "0x4D",
+          "red" : "0x31"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Topaz/Info.plist
+++ b/Topaz/Info.plist
@@ -4,5 +4,10 @@
 <dict>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Allow web pages opened in Topaz to find and connect to your Bluetooth devices.</string>
+	<key>UILaunchScreen</key>
+	<dict>
+		<key>UIColorName</key>
+		<string>LaunchBackground</string>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
For SwiftUI launch screen we use the super simple background color setting. Unfortunately this needs to be baked into the core asset catalog and cannot go in the `Design` sub-module so we duplicate the main topaz color.

I didn't capture a video demo, but the only difference here is that during launch we briefly see a blue screen instead of the default black screen.