### PR TITLE
Debug build of Js artifact

### DIFF
--- a/lib/Sources/WebView/Resources/Generated/BluetoothPolyfill.js
+++ b/lib/Sources/WebView/Resources/Generated/BluetoothPolyfill.js
@@ -1,1 +1,677 @@
-const e=e=>{throw(e=>{try{const t=JSON.parse(e.message);return new DOMException(t.msg,t.name)}catch(t){return new TypeError(`${t} when decoding "${e}"`)}})(e)},t=function(t,i){return window.webkit.messageHandlers.bluetooth.postMessage({action:t,data:i}).catch(e)},i=e=>{return t=new Uint8Array(e),btoa(String.fromCharCode(...t));var t},r=e=>new DataView((e=>Uint8Array.from(atob(e),(e=>e.codePointAt(0))))(e).buffer);function a(e){return new DataView(e.buffer.slice(0))}class n{constructor(e,i){this.characteristic=e,this.uuid=i,this.readValue=async()=>{const e=await t("readDescriptor",{device:this.characteristic.service.device.id,service:this.characteristic.service.uuid,characteristic:this.characteristic.uuid,instance:this.characteristic.instance,descriptor:this.uuid});return this.value=r(e),a(this.value)},this.value=null}}var s,o,c;!function(e){e[e.alert_notification=6161]="alert_notification",e[e.automation_io=6165]="automation_io",e[e.battery_service=6159]="battery_service",e[e.blood_pressure=6160]="blood_pressure",e[e.body_composition=6171]="body_composition",e[e.bond_management=6174]="bond_management",e[e.continuous_glucose_monitoring=6175]="continuous_glucose_monitoring",e[e.current_time=6149]="current_time",e[e.cycling_power=6168]="cycling_power",e[e.cycling_speed_and_cadence=6166]="cycling_speed_and_cadence",e[e.device_information=6154]="device_information",e[e.environmental_sensing=6170]="environmental_sensing",e[e.generic_access=6144]="generic_access",e[e.generic_attribute=6145]="generic_attribute",e[e.glucose=6152]="glucose",e[e.health_thermometer=6153]="health_thermometer",e[e.heart_rate=6157]="heart_rate",e[e.human_interface_device=6162]="human_interface_device",e[e.immediate_alert=6146]="immediate_alert",e[e.indoor_positioning=6177]="indoor_positioning",e[e.internet_protocol_support=6176]="internet_protocol_support",e[e.link_loss=6147]="link_loss",e[e.location_and_navigation=6169]="location_and_navigation",e[e.next_dst_change=6151]="next_dst_change",e[e.phone_alert_status=6158]="phone_alert_status",e[e.pulse_oximeter=6178]="pulse_oximeter",e[e.reference_time_update=6150]="reference_time_update",e[e.running_speed_and_cadence=6164]="running_speed_and_cadence",e[e.scan_parameters=6163]="scan_parameters",e[e.tx_power=6148]="tx_power",e[e.user_data=6172]="user_data",e[e.weight_scale=6173]="weight_scale"}(s||(s={})),function(e){e[e.aerobic_heart_rate_lower_limit=10878]="aerobic_heart_rate_lower_limit",e[e.aerobic_heart_rate_upper_limit=10884]="aerobic_heart_rate_upper_limit",e[e.aerobic_threshold=10879]="aerobic_threshold",e[e.age=10880]="age",e[e.aggregate=10842]="aggregate",e[e.alert_category_id=10819]="alert_category_id",e[e.alert_category_id_bit_mask=10818]="alert_category_id_bit_mask",e[e.alert_level=10758]="alert_level",e[e.alert_notification_control_point=10820]="alert_notification_control_point",e[e.alert_status=10815]="alert_status",e[e.altitude=10931]="altitude",e[e.anaerobic_heart_rate_lower_limit=10881]="anaerobic_heart_rate_lower_limit",e[e.anaerobic_heart_rate_upper_limit=10882]="anaerobic_heart_rate_upper_limit",e[e.anaerobic_threshold=10883]="anaerobic_threshold",e[e.analog=10840]="analog",e[e.apparent_wind_direction=10867]="apparent_wind_direction",e[e.apparent_wind_speed=10866]="apparent_wind_speed",e[e["gap.appearance"]=10753]="gap.appearance",e[e.barometric_pressure_trend=10915]="barometric_pressure_trend",e[e.battery_level=10777]="battery_level",e[e.blood_pressure_feature=10825]="blood_pressure_feature",e[e.blood_pressure_measurement=10805]="blood_pressure_measurement",e[e.body_composition_feature=10907]="body_composition_feature",e[e.body_composition_measurement=10908]="body_composition_measurement",e[e.body_sensor_location=10808]="body_sensor_location",e[e.bond_management_control_point=10916]="bond_management_control_point",e[e.bond_management_feature=10917]="bond_management_feature",e[e.boot_keyboard_input_report=10786]="boot_keyboard_input_report",e[e.boot_keyboard_output_report=10802]="boot_keyboard_output_report",e[e.boot_mouse_input_report=10803]="boot_mouse_input_report",e[e["gap.central_address_resolution_support"]=10918]="gap.central_address_resolution_support",e[e.cgm_feature=10920]="cgm_feature",e[e.cgm_measurement=10919]="cgm_measurement",e[e.cgm_session_run_time=10923]="cgm_session_run_time",e[e.cgm_session_start_time=10922]="cgm_session_start_time",e[e.cgm_specific_ops_control_point=10924]="cgm_specific_ops_control_point",e[e.cgm_status=10921]="cgm_status",e[e.csc_feature=10844]="csc_feature",e[e.csc_measurement=10843]="csc_measurement",e[e.current_time=10795]="current_time",e[e.cycling_power_control_point=10854]="cycling_power_control_point",e[e.cycling_power_feature=10853]="cycling_power_feature",e[e.cycling_power_measurement=10851]="cycling_power_measurement",e[e.cycling_power_vector=10852]="cycling_power_vector",e[e.database_change_increment=10905]="database_change_increment",e[e.date_of_birth=10885]="date_of_birth",e[e.date_of_threshold_assessment=10886]="date_of_threshold_assessment",e[e.date_time=10760]="date_time",e[e.day_date_time=10762]="day_date_time",e[e.day_of_week=10761]="day_of_week",e[e.descriptor_value_changed=10877]="descriptor_value_changed",e[e["gap.device_name"]=10752]="gap.device_name",e[e.dew_point=10875]="dew_point",e[e.digital=10838]="digital",e[e.dst_offset=10765]="dst_offset",e[e.elevation=10860]="elevation",e[e.email_address=10887]="email_address",e[e.exact_time_256=10764]="exact_time_256",e[e.fat_burn_heart_rate_lower_limit=10888]="fat_burn_heart_rate_lower_limit",e[e.fat_burn_heart_rate_upper_limit=10889]="fat_burn_heart_rate_upper_limit",e[e.firmware_revision_string=10790]="firmware_revision_string",e[e.first_name=10890]="first_name",e[e.five_zone_heart_rate_limits=10891]="five_zone_heart_rate_limits",e[e.floor_number=10930]="floor_number",e[e.gender=10892]="gender",e[e.glucose_feature=10833]="glucose_feature",e[e.glucose_measurement=10776]="glucose_measurement",e[e.glucose_measurement_context=10804]="glucose_measurement_context",e[e.gust_factor=10868]="gust_factor",e[e.hardware_revision_string=10791]="hardware_revision_string",e[e.heart_rate_control_point=10809]="heart_rate_control_point",e[e.heart_rate_max=10893]="heart_rate_max",e[e.heart_rate_measurement=10807]="heart_rate_measurement",e[e.heat_index=10874]="heat_index",e[e.height=10894]="height",e[e.hid_control_point=10828]="hid_control_point",e[e.hid_information=10826]="hid_information",e[e.hip_circumference=10895]="hip_circumference",e[e.humidity=10863]="humidity",e[e["ieee_11073-20601_regulatory_certification_data_list"]=10794]="ieee_11073-20601_regulatory_certification_data_list",e[e.indoor_positioning_configuration=10925]="indoor_positioning_configuration",e[e.intermediate_blood_pressure=10806]="intermediate_blood_pressure",e[e.intermediate_temperature=10782]="intermediate_temperature",e[e.irradiance=10871]="irradiance",e[e.language=10914]="language",e[e.last_name=10896]="last_name",e[e.latitude=10926]="latitude",e[e.ln_control_point=10859]="ln_control_point",e[e.ln_feature=10858]="ln_feature",e[e["local_east_coordinate.xml"]=10929]="local_east_coordinate.xml",e[e.local_north_coordinate=10928]="local_north_coordinate",e[e.local_time_information=10767]="local_time_information",e[e.location_and_speed=10855]="location_and_speed",e[e.location_name=10933]="location_name",e[e.longitude=10927]="longitude",e[e.magnetic_declination=10796]="magnetic_declination",e[e.magnetic_flux_density_2D=10912]="magnetic_flux_density_2D",e[e.magnetic_flux_density_3D=10913]="magnetic_flux_density_3D",e[e.manufacturer_name_string=10793]="manufacturer_name_string",e[e.maximum_recommended_heart_rate=10897]="maximum_recommended_heart_rate",e[e.measurement_interval=10785]="measurement_interval",e[e.model_number_string=10788]="model_number_string",e[e.navigation=10856]="navigation",e[e.new_alert=10822]="new_alert",e[e["gap.peripheral_preferred_connection_parameters"]=10756]="gap.peripheral_preferred_connection_parameters",e[e["gap.peripheral_privacy_flag"]=10754]="gap.peripheral_privacy_flag",e[e.plx_continuous_measurement=10847]="plx_continuous_measurement",e[e.plx_features=10848]="plx_features",e[e.plx_spot_check_measurement=10846]="plx_spot_check_measurement",e[e.pnp_id=10832]="pnp_id",e[e.pollen_concentration=10869]="pollen_concentration",e[e.position_quality=10857]="position_quality",e[e.pressure=10861]="pressure",e[e.protocol_mode=10830]="protocol_mode",e[e.rainfall=10872]="rainfall",e[e["gap.reconnection_address"]=10755]="gap.reconnection_address",e[e.record_access_control_point=10834]="record_access_control_point",e[e.reference_time_information=10772]="reference_time_information",e[e.report=10829]="report",e[e.report_map=10827]="report_map",e[e.resting_heart_rate=10898]="resting_heart_rate",e[e.ringer_control_point=10816]="ringer_control_point",e[e.ringer_setting=10817]="ringer_setting",e[e.rsc_feature=10836]="rsc_feature",e[e.rsc_measurement=10835]="rsc_measurement",e[e.sc_control_point=10837]="sc_control_point",e[e.scan_interval_window=10831]="scan_interval_window",e[e.scan_refresh=10801]="scan_refresh",e[e.sensor_location=10845]="sensor_location",e[e.serial_number_string=10789]="serial_number_string",e[e["gatt.service_changed"]=10757]="gatt.service_changed",e[e.software_revision_string=10792]="software_revision_string",e[e.sport_type_for_aerobic_and_anaerobic_thresholds=10899]="sport_type_for_aerobic_and_anaerobic_thresholds",e[e.supported_new_alert_category=10823]="supported_new_alert_category",e[e.supported_unread_alert_category=10824]="supported_unread_alert_category",e[e.system_id=10787]="system_id",e[e.temperature=10862]="temperature",e[e.temperature_measurement=10780]="temperature_measurement",e[e.temperature_type=10781]="temperature_type",e[e.three_zone_heart_rate_limits=10900]="three_zone_heart_rate_limits",e[e.time_accuracy=10770]="time_accuracy",e[e.time_source=10771]="time_source",e[e.time_update_control_point=10774]="time_update_control_point",e[e.time_update_state=10775]="time_update_state",e[e.time_with_dst=10769]="time_with_dst",e[e.time_zone=10766]="time_zone",e[e.true_wind_direction=10865]="true_wind_direction",e[e.true_wind_speed=10864]="true_wind_speed",e[e.two_zone_heart_rate_limit=10901]="two_zone_heart_rate_limit",e[e.tx_power_level=10759]="tx_power_level",e[e.uncertainty=10932]="uncertainty",e[e.unread_alert_status=10821]="unread_alert_status",e[e.user_control_point=10911]="user_control_point",e[e.user_index=10906]="user_index",e[e.uv_index=10870]="uv_index",e[e.vo2_max=10902]="vo2_max",e[e.waist_circumference=10903]="waist_circumference",e[e.weight=10904]="weight",e[e.weight_measurement=10909]="weight_measurement",e[e.weight_scale_feature=10910]="weight_scale_feature",e[e.wind_chill=10873]="wind_chill"}(o||(o={})),function(e){e[e["gatt.characteristic_extended_properties"]=10496]="gatt.characteristic_extended_properties",e[e["gatt.characteristic_user_description"]=10497]="gatt.characteristic_user_description",e[e["gatt.client_characteristic_configuration"]=10498]="gatt.client_characteristic_configuration",e[e["gatt.server_characteristic_configuration"]=10499]="gatt.server_characteristic_configuration",e[e["gatt.characteristic_presentation_format"]=10500]="gatt.characteristic_presentation_format",e[e["gatt.characteristic_aggregate_format"]=10501]="gatt.characteristic_aggregate_format",e[e.valid_range=10502]="valid_range",e[e.external_report_reference=10503]="external_report_reference",e[e.report_reference=10504]="report_reference",e[e.number_of_digitals=10505]="number_of_digitals",e[e.value_trigger_setting=10506]="value_trigger_setting",e[e.es_configuration=10507]="es_configuration",e[e.es_measurement=10508]="es_measurement",e[e.es_trigger_setting=10509]="es_trigger_setting",e[e.time_trigger_setting=10510]="time_trigger_setting"}(c||(c={}));const _=e=>("number"==typeof e&&(e=e.toString(16)),(e=e.toLowerCase()).length<=8&&(e=("00000000"+e).slice(-8)+"-0000-1000-8000-00805f9b34fb"),32===e.length&&(e=e.match(/^([0-9a-f]{8})([0-9a-f]{4})([0-9a-f]{4})([0-9a-f]{4})([0-9a-f]{12})$/).splice(1).join("-")),e),d={getService:e=>("string"==typeof e&&s[e]&&(e=s[e]),_(e)),getCharacteristic:e=>("string"==typeof e&&o[e]&&(e=o[e]),_(e)),getDescriptor:e=>("string"==typeof e&&c[e]&&(e=c[e]),_(e)),canonicalUUID:_};function u(e,t,i,r){if("a"===i&&!r)throw new TypeError("Private accessor was defined without a getter");if("function"==typeof t?e!==t||!r:!t.has(e))throw new TypeError("Cannot read private member from an object whose class did not declare it");return"m"===i?r:"a"===i?r.call(e):r?r.value:t.get(e)}var l;"function"==typeof SuppressedError&&SuppressedError;const h=(e,t)=>e+"."+t,p=e=>h(e.uuid,e.instance);l=new WeakMap;const m=new class{constructor(){l.set(this,void 0),this.getDevice=e=>{var t;return null===(t=u(this,l,"f").get(e))||void 0===t?void 0:t.device},this.addDevice=e=>{u(this,l,"f").get(e.id),u(this,l,"f").set(e.id,{uuid:e.id,device:e,services:new Map})},this.getService=(e,t)=>{var i,r;return null===(r=null===(i=u(this,l,"f").get(e))||void 0===i?void 0:i.services.get(t))||void 0===r?void 0:r.service},this.addService=e=>{const t=u(this,l,"f").get(e.device.id);if(!t)throw new ReferenceError(`Device ${e.device.id} not found`);t.services.set(e.uuid,{uuid:e.uuid,service:e,characteristics:new Map})},this.getCharacteristic=(e,t,i)=>{var r,a,n;return null===(n=null===(a=null===(r=u(this,l,"f").get(e.device.id))||void 0===r?void 0:r.services.get(e.uuid))||void 0===a?void 0:a.characteristics.get(h(t,i)))||void 0===n?void 0:n.characteristic},this.addCharacteristic=(e,t)=>{var i;const r=null===(i=u(this,l,"f").get(e.device.id))||void 0===i?void 0:i.services.get(e.uuid);if(!r)throw new ReferenceError(`Service ${e.uuid} not found`);r.characteristics.set(p(t),{uuid:t.uuid,characteristic:t,descriptors:new Map})},this.findCharacteristic=e=>{var t;for(const i of u(this,l,"f").values())for(const r of i.services.values()){const i=null===(t=r.characteristics.get(e))||void 0===t?void 0:t.characteristic;if(i)return i}},this.updateCharacteristicValue=(e,t)=>{const i=this.findCharacteristic(e);if(!i)throw new ReferenceError(`Characteristic ${e} not found`);return i.value=t,i},this.getDescriptor=(e,t)=>{var i,r,a;return null===(a=null===(r=null===(i=u(this,l,"f").get(e.service.device.id))||void 0===i?void 0:i.services.get(e.service.uuid))||void 0===r?void 0:r.characteristics.get(h(e.uuid,e.instance)))||void 0===a?void 0:a.descriptors.get(t)},this.addDescriptor=(e,t)=>{var i,r;const a=null===(r=null===(i=u(this,l,"f").get(e.service.device.id))||void 0===i?void 0:i.services.get(e.service.uuid))||void 0===r?void 0:r.characteristics.get(p(e));if(!a)throw new ReferenceError(`Characteristic ${e.uuid} not found`);a.descriptors.set(t.uuid,t)},function(e,t,i,r,a){if("m"===r)throw new TypeError("Private method is not writable");if("a"===r&&!a)throw new TypeError("Private accessor was defined without a setter");if("function"==typeof t?e!==t||!a:!t.has(e))throw new TypeError("Cannot write private member to an object whose class did not declare it");"a"===r?a.call(e,i):a?a.value=i:t.set(e,i)}(this,l,new Map,"f")}};class g extends EventTarget{constructor(e,r,s,o){super(),this.service=e,this.uuid=r,this.properties=s,this.instance=o,this.GetGATTChildren=async(e,i)=>(await t("discoverDescriptors",{device:this.service.device.id,service:this.service.uuid,characteristic:this.uuid,instance:this.instance,descriptor:i?d.getDescriptor(i):null,single:e})).map((e=>((e,t)=>{const i=m.getDescriptor(e,t);if(i)return i;const r=new n(e,t);return m.addDescriptor(e,r),r})(this,e))),this.getDescriptor=async e=>{if(void 0===e)throw new TypeError("Missing 'descriptor' UUID parameter.");return(await this.GetGATTChildren(!0,e))[0]},this.getDescriptors=async e=>this.GetGATTChildren(!1,e),this.readValue=async()=>(await t("readCharacteristic",{device:this.service.device.id,service:this.service.uuid,characteristic:this.uuid,instance:this.instance}),a(this.value)),this.startNotifications=async()=>(await t("startNotifications",{device:this.service.device.id,service:this.service.uuid,characteristic:this.uuid,instance:this.instance}),this),this.stopNotifications=async()=>(await t("stopNotifications",{device:this.service.device.id,service:this.service.uuid,characteristic:this.uuid,instance:this.instance}),this),this._writeValue=async(e,r)=>{const a=v(e)?e.buffer:e,n=i(a);await t("writeCharacteristic",{device:this.service.device.id,service:this.service.uuid,characteristic:this.uuid,instance:this.instance,value:n,withResponse:r})},this.writeValueWithResponse=async e=>this._writeValue(e,!0),this.writeValueWithoutResponse=async e=>this._writeValue(e,!1),this.value=null}}const v=e=>void 0!==e.buffer;class f extends EventTarget{constructor(e,i,r){super(),this.GetGATTChildren=async(e,i)=>(await t("discoverCharacteristics",{device:this.device.id,service:this.uuid,characteristic:i?d.getCharacteristic(i):null,single:e})).characteristics.map((e=>((e,t,i,r)=>{const a=m.getCharacteristic(e,t,r);if(a)return a;const n=new g(e,t,i,r);return m.addCharacteristic(e,n),n})(this,e.uuid,e.properties,e.instance))),this.getCharacteristic=async e=>{if(void 0===e)throw new TypeError("Missing 'characteristic' UUID parameter.");return(await this.GetGATTChildren(!0,e))[0]},this.getCharacteristics=async e=>this.GetGATTChildren(!1,e),this.device=e,this.uuid=i,this.isPrimary=r}}class w{constructor(e){this.connect=async()=>{const e=await t("connect",{uuid:this.device.id});return this.connected=e.connected,this},this.disconnect=async()=>{const e=await t("disconnect",{uuid:this.device.id});this.connected=!e.disconnected},this.GetGATTChildren=async(e,i)=>(await t("discoverServices",{device:this.device.id,service:i?d.getService(i):null,single:e})).services.map((e=>((e,t,i)=>{const r=m.getService(e.id,t);if(r)return r;const a=new f(e,t,i);return m.addService(a),a})(this.device,e,!0))),this.getPrimaryService=async e=>{if(void 0===e)throw new TypeError("Missing 'bluetoothServiceUUID' parameter.");return(await this.GetGATTChildren(!0,e))[0]},this.getPrimaryServices=async e=>this.GetGATTChildren(!1,e),this.device=e,this.connected=!1}}class y extends EventTarget{constructor(e,t){super(),this.id=e,this.name=t,this.gatt=new w(this)}}const b=(e,t)=>{const i=new y(e,t);return m.addDevice(i),i};class x extends EventTarget{constructor(){super(),this.onavailabilitychanged=e=>{},this.getAvailability=async()=>(await t("getAvailability")).isAvailable,this.getDevices=async()=>(await t("getDevices")).map((e=>b(e.uuid,e.name))),this.requestDevice=async e=>{const i=await t("requestDevice",{options:e});return b(i.uuid,i.name)},this.addEventListener("availabilitychanged",(e=>{this.onavailabilitychanged(e)}))}}class T extends Event{constructor(e,t){super(e,t),this.value=null==t?void 0:t.value}}class D{constructor(){this.sendEvent=e=>{(e=>{let t,i=[];if("bluetooth"===e.id)i.push(globalThis.topaz.bluetooth);else if("gattserverdisconnected"===e.name){const t=m.getDevice(e.id);t&&i.push(t)}else if("characteristicvaluechanged"===e.name){const a=r(e.data),n=m.updateCharacteristicValue(e.id,a);i.push(n),t=new T(e.name,{value:a})}t||(t=new T(e.name,{value:e.data}));for(const e of i)e.dispatchEvent(t)})(e)},this.bluetooth=new x}}void 0===navigator.bluetooth&&(globalThis.topaz=new D,navigator.bluetooth=globalThis.topaz.bluetooth),void 0===window.BluetoothUUID&&(globalThis.BluetoothUUID=d,window.BluetoothUUID=globalThis.BluetoothUUID);
+const transformToDOMException = (error) => {
+    try {
+        const decoded = JSON.parse(error.message);
+        return new DOMException(decoded.msg, decoded.name);
+    }
+    catch (e) {
+        return new TypeError(`${e} when decoding "${error}"`);
+    }
+};
+const rethrowAsDOMException = (error) => {
+    throw transformToDOMException(error);
+};
+
+const bluetoothRequest = function (action, data) {
+    return window.webkit.messageHandlers.bluetooth.postMessage({
+        action: action,
+        data: data
+    }).catch(rethrowAsDOMException);
+};
+
+const uint8ArrayToBase64 = (uint8array) => {
+    return btoa(String.fromCharCode(...uint8array));
+};
+const base64ToUint8Array = (base64) => {
+    return Uint8Array.from(atob(base64), (m) => m.codePointAt(0));
+};
+const arrayBufferToBase64 = (buffer) => {
+    return uint8ArrayToBase64(new Uint8Array(buffer));
+};
+const base64ToDataView = (base64) => {
+    return new DataView(base64ToUint8Array(base64).buffer);
+};
+function copyOf(data) {
+    return new DataView(data.buffer.slice(0));
+}
+
+class BluetoothRemoteGATTDescriptor {
+    constructor(characteristic, uuid) {
+        this.characteristic = characteristic;
+        this.uuid = uuid;
+        this.readValue = async () => {
+            const response = await bluetoothRequest('readDescriptor', {
+                device: this.characteristic.service.device.id,
+                service: this.characteristic.service.uuid,
+                characteristic: this.characteristic.uuid,
+                instance: this.characteristic.instance,
+                descriptor: this.uuid
+            });
+            this.value = base64ToDataView(response);
+            return copyOf(this.value);
+        };
+        this.value = null;
+    }
+}
+
+var bluetoothServices;
+(function (bluetoothServices) {
+    bluetoothServices[bluetoothServices["alert_notification"] = 6161] = "alert_notification";
+    bluetoothServices[bluetoothServices["automation_io"] = 6165] = "automation_io";
+    bluetoothServices[bluetoothServices["battery_service"] = 6159] = "battery_service";
+    bluetoothServices[bluetoothServices["blood_pressure"] = 6160] = "blood_pressure";
+    bluetoothServices[bluetoothServices["body_composition"] = 6171] = "body_composition";
+    bluetoothServices[bluetoothServices["bond_management"] = 6174] = "bond_management";
+    bluetoothServices[bluetoothServices["continuous_glucose_monitoring"] = 6175] = "continuous_glucose_monitoring";
+    bluetoothServices[bluetoothServices["current_time"] = 6149] = "current_time";
+    bluetoothServices[bluetoothServices["cycling_power"] = 6168] = "cycling_power";
+    bluetoothServices[bluetoothServices["cycling_speed_and_cadence"] = 6166] = "cycling_speed_and_cadence";
+    bluetoothServices[bluetoothServices["device_information"] = 6154] = "device_information";
+    bluetoothServices[bluetoothServices["environmental_sensing"] = 6170] = "environmental_sensing";
+    bluetoothServices[bluetoothServices["generic_access"] = 6144] = "generic_access";
+    bluetoothServices[bluetoothServices["generic_attribute"] = 6145] = "generic_attribute";
+    bluetoothServices[bluetoothServices["glucose"] = 6152] = "glucose";
+    bluetoothServices[bluetoothServices["health_thermometer"] = 6153] = "health_thermometer";
+    bluetoothServices[bluetoothServices["heart_rate"] = 6157] = "heart_rate";
+    bluetoothServices[bluetoothServices["human_interface_device"] = 6162] = "human_interface_device";
+    bluetoothServices[bluetoothServices["immediate_alert"] = 6146] = "immediate_alert";
+    bluetoothServices[bluetoothServices["indoor_positioning"] = 6177] = "indoor_positioning";
+    bluetoothServices[bluetoothServices["internet_protocol_support"] = 6176] = "internet_protocol_support";
+    bluetoothServices[bluetoothServices["link_loss"] = 6147] = "link_loss";
+    bluetoothServices[bluetoothServices["location_and_navigation"] = 6169] = "location_and_navigation";
+    bluetoothServices[bluetoothServices["next_dst_change"] = 6151] = "next_dst_change";
+    bluetoothServices[bluetoothServices["phone_alert_status"] = 6158] = "phone_alert_status";
+    bluetoothServices[bluetoothServices["pulse_oximeter"] = 6178] = "pulse_oximeter";
+    bluetoothServices[bluetoothServices["reference_time_update"] = 6150] = "reference_time_update";
+    bluetoothServices[bluetoothServices["running_speed_and_cadence"] = 6164] = "running_speed_and_cadence";
+    bluetoothServices[bluetoothServices["scan_parameters"] = 6163] = "scan_parameters";
+    bluetoothServices[bluetoothServices["tx_power"] = 6148] = "tx_power";
+    bluetoothServices[bluetoothServices["user_data"] = 6172] = "user_data";
+    bluetoothServices[bluetoothServices["weight_scale"] = 6173] = "weight_scale";
+})(bluetoothServices || (bluetoothServices = {}));
+var bluetoothCharacteristics;
+(function (bluetoothCharacteristics) {
+    bluetoothCharacteristics[bluetoothCharacteristics["aerobic_heart_rate_lower_limit"] = 10878] = "aerobic_heart_rate_lower_limit";
+    bluetoothCharacteristics[bluetoothCharacteristics["aerobic_heart_rate_upper_limit"] = 10884] = "aerobic_heart_rate_upper_limit";
+    bluetoothCharacteristics[bluetoothCharacteristics["aerobic_threshold"] = 10879] = "aerobic_threshold";
+    bluetoothCharacteristics[bluetoothCharacteristics["age"] = 10880] = "age";
+    bluetoothCharacteristics[bluetoothCharacteristics["aggregate"] = 10842] = "aggregate";
+    bluetoothCharacteristics[bluetoothCharacteristics["alert_category_id"] = 10819] = "alert_category_id";
+    bluetoothCharacteristics[bluetoothCharacteristics["alert_category_id_bit_mask"] = 10818] = "alert_category_id_bit_mask";
+    bluetoothCharacteristics[bluetoothCharacteristics["alert_level"] = 10758] = "alert_level";
+    bluetoothCharacteristics[bluetoothCharacteristics["alert_notification_control_point"] = 10820] = "alert_notification_control_point";
+    bluetoothCharacteristics[bluetoothCharacteristics["alert_status"] = 10815] = "alert_status";
+    bluetoothCharacteristics[bluetoothCharacteristics["altitude"] = 10931] = "altitude";
+    bluetoothCharacteristics[bluetoothCharacteristics["anaerobic_heart_rate_lower_limit"] = 10881] = "anaerobic_heart_rate_lower_limit";
+    bluetoothCharacteristics[bluetoothCharacteristics["anaerobic_heart_rate_upper_limit"] = 10882] = "anaerobic_heart_rate_upper_limit";
+    bluetoothCharacteristics[bluetoothCharacteristics["anaerobic_threshold"] = 10883] = "anaerobic_threshold";
+    bluetoothCharacteristics[bluetoothCharacteristics["analog"] = 10840] = "analog";
+    bluetoothCharacteristics[bluetoothCharacteristics["apparent_wind_direction"] = 10867] = "apparent_wind_direction";
+    bluetoothCharacteristics[bluetoothCharacteristics["apparent_wind_speed"] = 10866] = "apparent_wind_speed";
+    bluetoothCharacteristics[bluetoothCharacteristics["gap.appearance"] = 10753] = "gap.appearance";
+    bluetoothCharacteristics[bluetoothCharacteristics["barometric_pressure_trend"] = 10915] = "barometric_pressure_trend";
+    bluetoothCharacteristics[bluetoothCharacteristics["battery_level"] = 10777] = "battery_level";
+    bluetoothCharacteristics[bluetoothCharacteristics["blood_pressure_feature"] = 10825] = "blood_pressure_feature";
+    bluetoothCharacteristics[bluetoothCharacteristics["blood_pressure_measurement"] = 10805] = "blood_pressure_measurement";
+    bluetoothCharacteristics[bluetoothCharacteristics["body_composition_feature"] = 10907] = "body_composition_feature";
+    bluetoothCharacteristics[bluetoothCharacteristics["body_composition_measurement"] = 10908] = "body_composition_measurement";
+    bluetoothCharacteristics[bluetoothCharacteristics["body_sensor_location"] = 10808] = "body_sensor_location";
+    bluetoothCharacteristics[bluetoothCharacteristics["bond_management_control_point"] = 10916] = "bond_management_control_point";
+    bluetoothCharacteristics[bluetoothCharacteristics["bond_management_feature"] = 10917] = "bond_management_feature";
+    bluetoothCharacteristics[bluetoothCharacteristics["boot_keyboard_input_report"] = 10786] = "boot_keyboard_input_report";
+    bluetoothCharacteristics[bluetoothCharacteristics["boot_keyboard_output_report"] = 10802] = "boot_keyboard_output_report";
+    bluetoothCharacteristics[bluetoothCharacteristics["boot_mouse_input_report"] = 10803] = "boot_mouse_input_report";
+    bluetoothCharacteristics[bluetoothCharacteristics["gap.central_address_resolution_support"] = 10918] = "gap.central_address_resolution_support";
+    bluetoothCharacteristics[bluetoothCharacteristics["cgm_feature"] = 10920] = "cgm_feature";
+    bluetoothCharacteristics[bluetoothCharacteristics["cgm_measurement"] = 10919] = "cgm_measurement";
+    bluetoothCharacteristics[bluetoothCharacteristics["cgm_session_run_time"] = 10923] = "cgm_session_run_time";
+    bluetoothCharacteristics[bluetoothCharacteristics["cgm_session_start_time"] = 10922] = "cgm_session_start_time";
+    bluetoothCharacteristics[bluetoothCharacteristics["cgm_specific_ops_control_point"] = 10924] = "cgm_specific_ops_control_point";
+    bluetoothCharacteristics[bluetoothCharacteristics["cgm_status"] = 10921] = "cgm_status";
+    bluetoothCharacteristics[bluetoothCharacteristics["csc_feature"] = 10844] = "csc_feature";
+    bluetoothCharacteristics[bluetoothCharacteristics["csc_measurement"] = 10843] = "csc_measurement";
+    bluetoothCharacteristics[bluetoothCharacteristics["current_time"] = 10795] = "current_time";
+    bluetoothCharacteristics[bluetoothCharacteristics["cycling_power_control_point"] = 10854] = "cycling_power_control_point";
+    bluetoothCharacteristics[bluetoothCharacteristics["cycling_power_feature"] = 10853] = "cycling_power_feature";
+    bluetoothCharacteristics[bluetoothCharacteristics["cycling_power_measurement"] = 10851] = "cycling_power_measurement";
+    bluetoothCharacteristics[bluetoothCharacteristics["cycling_power_vector"] = 10852] = "cycling_power_vector";
+    bluetoothCharacteristics[bluetoothCharacteristics["database_change_increment"] = 10905] = "database_change_increment";
+    bluetoothCharacteristics[bluetoothCharacteristics["date_of_birth"] = 10885] = "date_of_birth";
+    bluetoothCharacteristics[bluetoothCharacteristics["date_of_threshold_assessment"] = 10886] = "date_of_threshold_assessment";
+    bluetoothCharacteristics[bluetoothCharacteristics["date_time"] = 10760] = "date_time";
+    bluetoothCharacteristics[bluetoothCharacteristics["day_date_time"] = 10762] = "day_date_time";
+    bluetoothCharacteristics[bluetoothCharacteristics["day_of_week"] = 10761] = "day_of_week";
+    bluetoothCharacteristics[bluetoothCharacteristics["descriptor_value_changed"] = 10877] = "descriptor_value_changed";
+    bluetoothCharacteristics[bluetoothCharacteristics["gap.device_name"] = 10752] = "gap.device_name";
+    bluetoothCharacteristics[bluetoothCharacteristics["dew_point"] = 10875] = "dew_point";
+    bluetoothCharacteristics[bluetoothCharacteristics["digital"] = 10838] = "digital";
+    bluetoothCharacteristics[bluetoothCharacteristics["dst_offset"] = 10765] = "dst_offset";
+    bluetoothCharacteristics[bluetoothCharacteristics["elevation"] = 10860] = "elevation";
+    bluetoothCharacteristics[bluetoothCharacteristics["email_address"] = 10887] = "email_address";
+    bluetoothCharacteristics[bluetoothCharacteristics["exact_time_256"] = 10764] = "exact_time_256";
+    bluetoothCharacteristics[bluetoothCharacteristics["fat_burn_heart_rate_lower_limit"] = 10888] = "fat_burn_heart_rate_lower_limit";
+    bluetoothCharacteristics[bluetoothCharacteristics["fat_burn_heart_rate_upper_limit"] = 10889] = "fat_burn_heart_rate_upper_limit";
+    bluetoothCharacteristics[bluetoothCharacteristics["firmware_revision_string"] = 10790] = "firmware_revision_string";
+    bluetoothCharacteristics[bluetoothCharacteristics["first_name"] = 10890] = "first_name";
+    bluetoothCharacteristics[bluetoothCharacteristics["five_zone_heart_rate_limits"] = 10891] = "five_zone_heart_rate_limits";
+    bluetoothCharacteristics[bluetoothCharacteristics["floor_number"] = 10930] = "floor_number";
+    bluetoothCharacteristics[bluetoothCharacteristics["gender"] = 10892] = "gender";
+    bluetoothCharacteristics[bluetoothCharacteristics["glucose_feature"] = 10833] = "glucose_feature";
+    bluetoothCharacteristics[bluetoothCharacteristics["glucose_measurement"] = 10776] = "glucose_measurement";
+    bluetoothCharacteristics[bluetoothCharacteristics["glucose_measurement_context"] = 10804] = "glucose_measurement_context";
+    bluetoothCharacteristics[bluetoothCharacteristics["gust_factor"] = 10868] = "gust_factor";
+    bluetoothCharacteristics[bluetoothCharacteristics["hardware_revision_string"] = 10791] = "hardware_revision_string";
+    bluetoothCharacteristics[bluetoothCharacteristics["heart_rate_control_point"] = 10809] = "heart_rate_control_point";
+    bluetoothCharacteristics[bluetoothCharacteristics["heart_rate_max"] = 10893] = "heart_rate_max";
+    bluetoothCharacteristics[bluetoothCharacteristics["heart_rate_measurement"] = 10807] = "heart_rate_measurement";
+    bluetoothCharacteristics[bluetoothCharacteristics["heat_index"] = 10874] = "heat_index";
+    bluetoothCharacteristics[bluetoothCharacteristics["height"] = 10894] = "height";
+    bluetoothCharacteristics[bluetoothCharacteristics["hid_control_point"] = 10828] = "hid_control_point";
+    bluetoothCharacteristics[bluetoothCharacteristics["hid_information"] = 10826] = "hid_information";
+    bluetoothCharacteristics[bluetoothCharacteristics["hip_circumference"] = 10895] = "hip_circumference";
+    bluetoothCharacteristics[bluetoothCharacteristics["humidity"] = 10863] = "humidity";
+    bluetoothCharacteristics[bluetoothCharacteristics["ieee_11073-20601_regulatory_certification_data_list"] = 10794] = "ieee_11073-20601_regulatory_certification_data_list";
+    bluetoothCharacteristics[bluetoothCharacteristics["indoor_positioning_configuration"] = 10925] = "indoor_positioning_configuration";
+    bluetoothCharacteristics[bluetoothCharacteristics["intermediate_blood_pressure"] = 10806] = "intermediate_blood_pressure";
+    bluetoothCharacteristics[bluetoothCharacteristics["intermediate_temperature"] = 10782] = "intermediate_temperature";
+    bluetoothCharacteristics[bluetoothCharacteristics["irradiance"] = 10871] = "irradiance";
+    bluetoothCharacteristics[bluetoothCharacteristics["language"] = 10914] = "language";
+    bluetoothCharacteristics[bluetoothCharacteristics["last_name"] = 10896] = "last_name";
+    bluetoothCharacteristics[bluetoothCharacteristics["latitude"] = 10926] = "latitude";
+    bluetoothCharacteristics[bluetoothCharacteristics["ln_control_point"] = 10859] = "ln_control_point";
+    bluetoothCharacteristics[bluetoothCharacteristics["ln_feature"] = 10858] = "ln_feature";
+    bluetoothCharacteristics[bluetoothCharacteristics["local_east_coordinate.xml"] = 10929] = "local_east_coordinate.xml";
+    bluetoothCharacteristics[bluetoothCharacteristics["local_north_coordinate"] = 10928] = "local_north_coordinate";
+    bluetoothCharacteristics[bluetoothCharacteristics["local_time_information"] = 10767] = "local_time_information";
+    bluetoothCharacteristics[bluetoothCharacteristics["location_and_speed"] = 10855] = "location_and_speed";
+    bluetoothCharacteristics[bluetoothCharacteristics["location_name"] = 10933] = "location_name";
+    bluetoothCharacteristics[bluetoothCharacteristics["longitude"] = 10927] = "longitude";
+    bluetoothCharacteristics[bluetoothCharacteristics["magnetic_declination"] = 10796] = "magnetic_declination";
+    bluetoothCharacteristics[bluetoothCharacteristics["magnetic_flux_density_2D"] = 10912] = "magnetic_flux_density_2D";
+    bluetoothCharacteristics[bluetoothCharacteristics["magnetic_flux_density_3D"] = 10913] = "magnetic_flux_density_3D";
+    bluetoothCharacteristics[bluetoothCharacteristics["manufacturer_name_string"] = 10793] = "manufacturer_name_string";
+    bluetoothCharacteristics[bluetoothCharacteristics["maximum_recommended_heart_rate"] = 10897] = "maximum_recommended_heart_rate";
+    bluetoothCharacteristics[bluetoothCharacteristics["measurement_interval"] = 10785] = "measurement_interval";
+    bluetoothCharacteristics[bluetoothCharacteristics["model_number_string"] = 10788] = "model_number_string";
+    bluetoothCharacteristics[bluetoothCharacteristics["navigation"] = 10856] = "navigation";
+    bluetoothCharacteristics[bluetoothCharacteristics["new_alert"] = 10822] = "new_alert";
+    bluetoothCharacteristics[bluetoothCharacteristics["gap.peripheral_preferred_connection_parameters"] = 10756] = "gap.peripheral_preferred_connection_parameters";
+    bluetoothCharacteristics[bluetoothCharacteristics["gap.peripheral_privacy_flag"] = 10754] = "gap.peripheral_privacy_flag";
+    bluetoothCharacteristics[bluetoothCharacteristics["plx_continuous_measurement"] = 10847] = "plx_continuous_measurement";
+    bluetoothCharacteristics[bluetoothCharacteristics["plx_features"] = 10848] = "plx_features";
+    bluetoothCharacteristics[bluetoothCharacteristics["plx_spot_check_measurement"] = 10846] = "plx_spot_check_measurement";
+    bluetoothCharacteristics[bluetoothCharacteristics["pnp_id"] = 10832] = "pnp_id";
+    bluetoothCharacteristics[bluetoothCharacteristics["pollen_concentration"] = 10869] = "pollen_concentration";
+    bluetoothCharacteristics[bluetoothCharacteristics["position_quality"] = 10857] = "position_quality";
+    bluetoothCharacteristics[bluetoothCharacteristics["pressure"] = 10861] = "pressure";
+    bluetoothCharacteristics[bluetoothCharacteristics["protocol_mode"] = 10830] = "protocol_mode";
+    bluetoothCharacteristics[bluetoothCharacteristics["rainfall"] = 10872] = "rainfall";
+    bluetoothCharacteristics[bluetoothCharacteristics["gap.reconnection_address"] = 10755] = "gap.reconnection_address";
+    bluetoothCharacteristics[bluetoothCharacteristics["record_access_control_point"] = 10834] = "record_access_control_point";
+    bluetoothCharacteristics[bluetoothCharacteristics["reference_time_information"] = 10772] = "reference_time_information";
+    bluetoothCharacteristics[bluetoothCharacteristics["report"] = 10829] = "report";
+    bluetoothCharacteristics[bluetoothCharacteristics["report_map"] = 10827] = "report_map";
+    bluetoothCharacteristics[bluetoothCharacteristics["resting_heart_rate"] = 10898] = "resting_heart_rate";
+    bluetoothCharacteristics[bluetoothCharacteristics["ringer_control_point"] = 10816] = "ringer_control_point";
+    bluetoothCharacteristics[bluetoothCharacteristics["ringer_setting"] = 10817] = "ringer_setting";
+    bluetoothCharacteristics[bluetoothCharacteristics["rsc_feature"] = 10836] = "rsc_feature";
+    bluetoothCharacteristics[bluetoothCharacteristics["rsc_measurement"] = 10835] = "rsc_measurement";
+    bluetoothCharacteristics[bluetoothCharacteristics["sc_control_point"] = 10837] = "sc_control_point";
+    bluetoothCharacteristics[bluetoothCharacteristics["scan_interval_window"] = 10831] = "scan_interval_window";
+    bluetoothCharacteristics[bluetoothCharacteristics["scan_refresh"] = 10801] = "scan_refresh";
+    bluetoothCharacteristics[bluetoothCharacteristics["sensor_location"] = 10845] = "sensor_location";
+    bluetoothCharacteristics[bluetoothCharacteristics["serial_number_string"] = 10789] = "serial_number_string";
+    bluetoothCharacteristics[bluetoothCharacteristics["gatt.service_changed"] = 10757] = "gatt.service_changed";
+    bluetoothCharacteristics[bluetoothCharacteristics["software_revision_string"] = 10792] = "software_revision_string";
+    bluetoothCharacteristics[bluetoothCharacteristics["sport_type_for_aerobic_and_anaerobic_thresholds"] = 10899] = "sport_type_for_aerobic_and_anaerobic_thresholds";
+    bluetoothCharacteristics[bluetoothCharacteristics["supported_new_alert_category"] = 10823] = "supported_new_alert_category";
+    bluetoothCharacteristics[bluetoothCharacteristics["supported_unread_alert_category"] = 10824] = "supported_unread_alert_category";
+    bluetoothCharacteristics[bluetoothCharacteristics["system_id"] = 10787] = "system_id";
+    bluetoothCharacteristics[bluetoothCharacteristics["temperature"] = 10862] = "temperature";
+    bluetoothCharacteristics[bluetoothCharacteristics["temperature_measurement"] = 10780] = "temperature_measurement";
+    bluetoothCharacteristics[bluetoothCharacteristics["temperature_type"] = 10781] = "temperature_type";
+    bluetoothCharacteristics[bluetoothCharacteristics["three_zone_heart_rate_limits"] = 10900] = "three_zone_heart_rate_limits";
+    bluetoothCharacteristics[bluetoothCharacteristics["time_accuracy"] = 10770] = "time_accuracy";
+    bluetoothCharacteristics[bluetoothCharacteristics["time_source"] = 10771] = "time_source";
+    bluetoothCharacteristics[bluetoothCharacteristics["time_update_control_point"] = 10774] = "time_update_control_point";
+    bluetoothCharacteristics[bluetoothCharacteristics["time_update_state"] = 10775] = "time_update_state";
+    bluetoothCharacteristics[bluetoothCharacteristics["time_with_dst"] = 10769] = "time_with_dst";
+    bluetoothCharacteristics[bluetoothCharacteristics["time_zone"] = 10766] = "time_zone";
+    bluetoothCharacteristics[bluetoothCharacteristics["true_wind_direction"] = 10865] = "true_wind_direction";
+    bluetoothCharacteristics[bluetoothCharacteristics["true_wind_speed"] = 10864] = "true_wind_speed";
+    bluetoothCharacteristics[bluetoothCharacteristics["two_zone_heart_rate_limit"] = 10901] = "two_zone_heart_rate_limit";
+    bluetoothCharacteristics[bluetoothCharacteristics["tx_power_level"] = 10759] = "tx_power_level";
+    bluetoothCharacteristics[bluetoothCharacteristics["uncertainty"] = 10932] = "uncertainty";
+    bluetoothCharacteristics[bluetoothCharacteristics["unread_alert_status"] = 10821] = "unread_alert_status";
+    bluetoothCharacteristics[bluetoothCharacteristics["user_control_point"] = 10911] = "user_control_point";
+    bluetoothCharacteristics[bluetoothCharacteristics["user_index"] = 10906] = "user_index";
+    bluetoothCharacteristics[bluetoothCharacteristics["uv_index"] = 10870] = "uv_index";
+    bluetoothCharacteristics[bluetoothCharacteristics["vo2_max"] = 10902] = "vo2_max";
+    bluetoothCharacteristics[bluetoothCharacteristics["waist_circumference"] = 10903] = "waist_circumference";
+    bluetoothCharacteristics[bluetoothCharacteristics["weight"] = 10904] = "weight";
+    bluetoothCharacteristics[bluetoothCharacteristics["weight_measurement"] = 10909] = "weight_measurement";
+    bluetoothCharacteristics[bluetoothCharacteristics["weight_scale_feature"] = 10910] = "weight_scale_feature";
+    bluetoothCharacteristics[bluetoothCharacteristics["wind_chill"] = 10873] = "wind_chill";
+})(bluetoothCharacteristics || (bluetoothCharacteristics = {}));
+var bluetoothDescriptors;
+(function (bluetoothDescriptors) {
+    bluetoothDescriptors[bluetoothDescriptors["gatt.characteristic_extended_properties"] = 10496] = "gatt.characteristic_extended_properties";
+    bluetoothDescriptors[bluetoothDescriptors["gatt.characteristic_user_description"] = 10497] = "gatt.characteristic_user_description";
+    bluetoothDescriptors[bluetoothDescriptors["gatt.client_characteristic_configuration"] = 10498] = "gatt.client_characteristic_configuration";
+    bluetoothDescriptors[bluetoothDescriptors["gatt.server_characteristic_configuration"] = 10499] = "gatt.server_characteristic_configuration";
+    bluetoothDescriptors[bluetoothDescriptors["gatt.characteristic_presentation_format"] = 10500] = "gatt.characteristic_presentation_format";
+    bluetoothDescriptors[bluetoothDescriptors["gatt.characteristic_aggregate_format"] = 10501] = "gatt.characteristic_aggregate_format";
+    bluetoothDescriptors[bluetoothDescriptors["valid_range"] = 10502] = "valid_range";
+    bluetoothDescriptors[bluetoothDescriptors["external_report_reference"] = 10503] = "external_report_reference";
+    bluetoothDescriptors[bluetoothDescriptors["report_reference"] = 10504] = "report_reference";
+    bluetoothDescriptors[bluetoothDescriptors["number_of_digitals"] = 10505] = "number_of_digitals";
+    bluetoothDescriptors[bluetoothDescriptors["value_trigger_setting"] = 10506] = "value_trigger_setting";
+    bluetoothDescriptors[bluetoothDescriptors["es_configuration"] = 10507] = "es_configuration";
+    bluetoothDescriptors[bluetoothDescriptors["es_measurement"] = 10508] = "es_measurement";
+    bluetoothDescriptors[bluetoothDescriptors["es_trigger_setting"] = 10509] = "es_trigger_setting";
+    bluetoothDescriptors[bluetoothDescriptors["time_trigger_setting"] = 10510] = "time_trigger_setting";
+})(bluetoothDescriptors || (bluetoothDescriptors = {}));
+const canonicalUUID = (alias) => {
+    if (typeof alias === 'number')
+        alias = alias.toString(16);
+    alias = alias.toLowerCase();
+    if (alias.length <= 8)
+        alias = ('00000000' + alias).slice(-8) + '-0000-1000-8000-00805f9b34fb';
+    if (alias.length === 32)
+        alias = alias.match(/^([0-9a-f]{8})([0-9a-f]{4})([0-9a-f]{4})([0-9a-f]{4})([0-9a-f]{12})$/).splice(1).join('-');
+    return alias;
+};
+const getService = (name) => {
+    if (typeof name === 'string' && bluetoothServices[name]) {
+        name = bluetoothServices[name];
+    }
+    return canonicalUUID(name);
+};
+const getCharacteristic = (name) => {
+    if (typeof name === 'string' && bluetoothCharacteristics[name]) {
+        name = bluetoothCharacteristics[name];
+    }
+    return canonicalUUID(name);
+};
+const getDescriptor = (name) => {
+    if (typeof name === 'string' && bluetoothDescriptors[name]) {
+        name = bluetoothDescriptors[name];
+    }
+    return canonicalUUID(name);
+};
+const BluetoothUUID = {
+    getService,
+    getCharacteristic,
+    getDescriptor,
+    canonicalUUID
+};
+
+/******************************************************************************
+Copyright (c) Microsoft Corporation.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+***************************************************************************** */
+/* global Reflect, Promise, SuppressedError, Symbol, Iterator */
+
+
+function __classPrivateFieldGet(receiver, state, kind, f) {
+    if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
+    if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
+    return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
+}
+
+function __classPrivateFieldSet(receiver, state, value, kind, f) {
+    if (kind === "m") throw new TypeError("Private method is not writable");
+    if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
+    if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
+    return (kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value)), value;
+}
+
+typeof SuppressedError === "function" ? SuppressedError : function (error, suppressed, message) {
+    var e = new Error(message);
+    return e.name = "SuppressedError", e.error = error, e.suppressed = suppressed, e;
+};
+
+var _Store_devices;
+const characteristicKey = (uuid, instance) => {
+    return uuid + '.' + instance;
+};
+const keyForCharacteristic = (characteristic) => {
+    return characteristicKey(characteristic.uuid, characteristic.instance);
+};
+class Store {
+    constructor() {
+        _Store_devices.set(this, undefined);
+        this.getDevice = (uuid) => {
+            var _a;
+            return (_a = __classPrivateFieldGet(this, _Store_devices, "f").get(uuid)) === null || _a === undefined ? undefined : _a.device;
+        };
+        this.addDevice = (device) => {
+            __classPrivateFieldGet(this, _Store_devices, "f").get(device.id);
+            __classPrivateFieldGet(this, _Store_devices, "f").set(device.id, { uuid: device.id, device, services: new Map() });
+        };
+        this.getService = (deviceUuid, serviceUuid) => {
+            var _a, _b;
+            return (_b = (_a = __classPrivateFieldGet(this, _Store_devices, "f").get(deviceUuid)) === null || _a === undefined ? undefined : _a.services.get(serviceUuid)) === null || _b === undefined ? undefined : _b.service;
+        };
+        this.addService = (service) => {
+            const deviceRecord = __classPrivateFieldGet(this, _Store_devices, "f").get(service.device.id);
+            if (!deviceRecord) {
+                throw new ReferenceError(`Device ${service.device.id} not found`);
+            }
+            deviceRecord.services.set(service.uuid, { uuid: service.uuid, service, characteristics: new Map() });
+        };
+        this.getCharacteristic = (service, uuid, instance) => {
+            var _a, _b, _c;
+            return (_c = (_b = (_a = __classPrivateFieldGet(this, _Store_devices, "f").get(service.device.id)) === null || _a === undefined ? undefined : _a.services.get(service.uuid)) === null || _b === undefined ? undefined : _b.characteristics.get(characteristicKey(uuid, instance))) === null || _c === undefined ? undefined : _c.characteristic;
+        };
+        this.addCharacteristic = (service, characteristic) => {
+            var _a;
+            const serviceRecord = (_a = __classPrivateFieldGet(this, _Store_devices, "f").get(service.device.id)) === null || _a === undefined ? undefined : _a.services.get(service.uuid);
+            if (!serviceRecord) {
+                throw new ReferenceError(`Service ${service.uuid} not found`);
+            }
+            serviceRecord.characteristics.set(keyForCharacteristic(characteristic), { uuid: characteristic.uuid, characteristic, descriptors: new Map() });
+        };
+        this.findCharacteristic = (key) => {
+            var _a;
+            for (const deviceRecord of __classPrivateFieldGet(this, _Store_devices, "f").values()) {
+                for (const serviceRecord of deviceRecord.services.values()) {
+                    const characteristic = (_a = serviceRecord.characteristics.get(key)) === null || _a === undefined ? undefined : _a.characteristic;
+                    if (characteristic) {
+                        return characteristic;
+                    }
+                }
+            }
+            return undefined;
+        };
+        this.updateCharacteristicValue = (key, value) => {
+            const characteristic = this.findCharacteristic(key);
+            if (!characteristic) {
+                throw new ReferenceError(`Characteristic ${key} not found`);
+            }
+            characteristic.value = value;
+            return characteristic;
+        };
+        this.getDescriptor = (characteristic, uuid) => {
+            var _a, _b, _c;
+            return (_c = (_b = (_a = __classPrivateFieldGet(this, _Store_devices, "f")
+                .get(characteristic.service.device.id)) === null || _a === undefined ? undefined : _a.services.get(characteristic.service.uuid)) === null || _b === undefined ? undefined : _b.characteristics.get(characteristicKey(characteristic.uuid, characteristic.instance))) === null || _c === undefined ? undefined : _c.descriptors.get(uuid);
+        };
+        this.addDescriptor = (characteristic, descriptor) => {
+            var _a, _b;
+            const characteristicRecord = (_b = (_a = __classPrivateFieldGet(this, _Store_devices, "f")
+                .get(characteristic.service.device.id)) === null || _a === undefined ? undefined : _a.services.get(characteristic.service.uuid)) === null || _b === undefined ? undefined : _b.characteristics.get(keyForCharacteristic(characteristic));
+            if (!characteristicRecord) {
+                throw new ReferenceError(`Characteristic ${characteristic.uuid} not found`);
+            }
+            characteristicRecord.descriptors.set(descriptor.uuid, descriptor);
+        };
+        __classPrivateFieldSet(this, _Store_devices, new Map(), "f");
+    }
+}
+_Store_devices = new WeakMap();
+const store = new Store();
+
+const getOrCreateDescriptor = (characteristic, uuid) => {
+    const existingDescriptor = store.getDescriptor(characteristic, uuid);
+    if (existingDescriptor) {
+        return existingDescriptor;
+    }
+    const descriptor = new BluetoothRemoteGATTDescriptor(characteristic, uuid);
+    store.addDescriptor(characteristic, descriptor);
+    return descriptor;
+};
+class BluetoothRemoteGATTCharacteristic extends EventTarget {
+    constructor(service, uuid, properties, instance) {
+        super();
+        this.service = service;
+        this.uuid = uuid;
+        this.properties = properties;
+        this.instance = instance;
+        this.GetGATTChildren = async (single, descriptor) => {
+            const response = await bluetoothRequest('discoverDescriptors', {
+                device: this.service.device.id,
+                service: this.service.uuid,
+                characteristic: this.uuid,
+                instance: this.instance,
+                descriptor: descriptor ? BluetoothUUID.getDescriptor(descriptor) : null,
+                single: single
+            });
+            return response.map(uuid => getOrCreateDescriptor(this, uuid));
+        };
+        this.getDescriptor = async (descriptor) => {
+            if (typeof descriptor === "undefined") {
+                throw new TypeError("Missing 'descriptor' UUID parameter.");
+            }
+            const descriptors = await this.GetGATTChildren(true, descriptor);
+            return descriptors[0];
+        };
+        this.getDescriptors = async (descriptor) => {
+            return this.GetGATTChildren(false, descriptor);
+        };
+        this.readValue = async () => {
+            await bluetoothRequest('readCharacteristic', {
+                device: this.service.device.id,
+                service: this.service.uuid,
+                characteristic: this.uuid,
+                instance: this.instance
+            });
+            return copyOf(this.value);
+        };
+        this.startNotifications = async () => {
+            await bluetoothRequest('startNotifications', {
+                device: this.service.device.id,
+                service: this.service.uuid,
+                characteristic: this.uuid,
+                instance: this.instance
+            });
+            return this;
+        };
+        this.stopNotifications = async () => {
+            await bluetoothRequest('stopNotifications', {
+                device: this.service.device.id,
+                service: this.service.uuid,
+                characteristic: this.uuid,
+                instance: this.instance
+            });
+            return this;
+        };
+        this._writeValue = async (value, withResponse) => {
+            const arrayBuffer = isView(value) ? value.buffer : value;
+            const base64 = arrayBufferToBase64(arrayBuffer);
+            await bluetoothRequest('writeCharacteristic', {
+                device: this.service.device.id,
+                service: this.service.uuid,
+                characteristic: this.uuid,
+                instance: this.instance,
+                value: base64,
+                withResponse: withResponse
+            });
+        };
+        this.writeValueWithResponse = async (value) => {
+            return this._writeValue(value, true);
+        };
+        this.writeValueWithoutResponse = async (value) => {
+            return this._writeValue(value, false);
+        };
+        this.value = null;
+    }
+}
+const isView = (source) => source.buffer !== undefined;
+
+const getOrCreateCharacteristic = (service, uuid, properties, instance) => {
+    const existingCharacteristic = store.getCharacteristic(service, uuid, instance);
+    if (existingCharacteristic) {
+        return existingCharacteristic;
+    }
+    const characteristic = new BluetoothRemoteGATTCharacteristic(service, uuid, properties, instance);
+    store.addCharacteristic(service, characteristic);
+    return characteristic;
+};
+class BluetoothRemoteGATTService extends EventTarget {
+    constructor(device, uuid, isPrimary) {
+        super();
+        this.GetGATTChildren = async (single, characteristic) => {
+            const response = await bluetoothRequest('discoverCharacteristics', {
+                device: this.device.id,
+                service: this.uuid,
+                characteristic: characteristic ? BluetoothUUID.getCharacteristic(characteristic) : null,
+                single: single
+            });
+            return response.characteristics.map(characteristic => getOrCreateCharacteristic(this, characteristic.uuid, characteristic.properties, characteristic.instance));
+        };
+        this.getCharacteristic = async (characteristic) => {
+            if (typeof characteristic === "undefined") {
+                throw new TypeError("Missing 'characteristic' UUID parameter.");
+            }
+            const characteristics = await this.GetGATTChildren(true, characteristic);
+            return characteristics[0];
+        };
+        this.getCharacteristics = async (characteristic) => {
+            return this.GetGATTChildren(false, characteristic);
+        };
+        this.device = device;
+        this.uuid = uuid;
+        this.isPrimary = isPrimary;
+    }
+}
+
+const getOrCreateService = (device, uuid, isPrimary) => {
+    const existingService = store.getService(device.id, uuid);
+    if (existingService) {
+        return existingService;
+    }
+    const service = new BluetoothRemoteGATTService(device, uuid, isPrimary);
+    store.addService(service);
+    return service;
+};
+class BluetoothRemoteGATTServer {
+    constructor(device) {
+        this.connect = async () => {
+            const response = await bluetoothRequest('connect', { uuid: this.device.id });
+            this.connected = response.connected;
+            return this;
+        };
+        this.disconnect = async () => {
+            const response = await bluetoothRequest('disconnect', { uuid: this.device.id });
+            this.connected = !response.disconnected;
+        };
+        this.GetGATTChildren = async (single, service) => {
+            const response = await bluetoothRequest('discoverServices', {
+                device: this.device.id,
+                service: service ? BluetoothUUID.getService(service) : null,
+                single: single
+            });
+            return response.services.map(service => getOrCreateService(this.device, service, true));
+        };
+        this.getPrimaryService = async (bluetoothServiceUUID) => {
+            if (typeof bluetoothServiceUUID === "undefined") {
+                throw new TypeError("Missing 'bluetoothServiceUUID' parameter.");
+            }
+            const services = await this.GetGATTChildren(true, bluetoothServiceUUID);
+            return services[0];
+        };
+        this.getPrimaryServices = async (bluetoothServiceUUID) => {
+            return this.GetGATTChildren(false, bluetoothServiceUUID);
+        };
+        this.device = device;
+        this.connected = false;
+    }
+}
+
+class BluetoothDevice extends EventTarget {
+    constructor(id, name) {
+        super();
+        this.id = id;
+        this.name = name;
+        this.gatt = new BluetoothRemoteGATTServer(this);
+    }
+}
+
+const createDevice = (uuid, name) => {
+    const device = new BluetoothDevice(uuid, name);
+    store.addDevice(device);
+    return device;
+};
+class Bluetooth extends EventTarget {
+    constructor() {
+        super();
+        this.onavailabilitychanged = (event) => {
+        };
+        this.getAvailability = async () => {
+            const response = await bluetoothRequest('getAvailability');
+            return response.isAvailable;
+        };
+        this.getDevices = async () => {
+            const response = await bluetoothRequest('getDevices');
+            return response.map(device => createDevice(device.uuid, device.name));
+        };
+        this.requestDevice = async (options) => {
+            const response = await bluetoothRequest('requestDevice', { options: options });
+            return createDevice(response.uuid, response.name);
+        };
+        this.addEventListener('availabilitychanged', (event) => {
+            this.onavailabilitychanged(event);
+        });
+    }
+}
+
+class ValueEvent extends Event {
+    constructor(type, eventInitDict) {
+        super(type, eventInitDict);
+        this.value = eventInitDict === null || eventInitDict === undefined ? undefined : eventInitDict.value;
+    }
+}
+
+const processEvent = (event) => {
+    let eventToSend;
+    let targets = [];
+    if (event.id === 'bluetooth') {
+        targets.push(globalThis.topaz.bluetooth);
+    }
+    else if (event.name === 'gattserverdisconnected') {
+        const device = store.getDevice(event.id);
+        if (device) {
+            targets.push(device);
+        }
+    }
+    else if (event.name === 'characteristicvaluechanged') {
+        const data = base64ToDataView(event.data);
+        const characteristic = store.updateCharacteristicValue(event.id, data);
+        targets.push(characteristic);
+        eventToSend = new ValueEvent(event.name, { value: data });
+    }
+    if (!eventToSend) {
+        eventToSend = new ValueEvent(event.name, { value: event.data });
+    }
+    for (const target of targets) {
+        target.dispatchEvent(eventToSend);
+    }
+};
+
+class Topaz {
+    constructor() {
+        this.sendEvent = (event) => {
+            processEvent(event);
+        };
+        this.bluetooth = new Bluetooth();
+    }
+}
+
+if (typeof (navigator.bluetooth) === 'undefined') {
+    globalThis.topaz = new Topaz();
+    navigator.bluetooth = globalThis.topaz.bluetooth;
+}
+if (typeof (window.BluetoothUUID) === 'undefined') {
+    globalThis.BluetoothUUID = BluetoothUUID;
+    window.BluetoothUUID = globalThis.BluetoothUUID;
+}


### PR DESCRIPTION
In the production build the `BluetoothDevice` class is minified as:
```js
class y extends EventTarget {
    constructor(e,t) {
        super(),this.id=e,this.name=t,this.gatt=new w(this)
    }
}
```

The long-term fix is to expose the public API classes under their real name in the global scope. For now we can ship the debug build which will work fine but be slightly slower to compile. We have to commit the build so that the CI publish task can ship it in the app build.