### PR TITLE
CA-4172: Fix back button

### DIFF
--- a/lib/Sources/WebView/WebNavigator.swift
+++ b/lib/Sources/WebView/WebNavigator.swift
@@ -29,10 +29,12 @@ public final class WebNavigator {
     }
 
     public func goForward() {
+        self.webView?.stopLoading()
         self.webView?.goForward()
     }
 
     public func goBack() {
+        self.webView?.stopLoading()
         self.webView?.goBack()
     }
 


### PR DESCRIPTION
The error we were getting on hitting the back button was a -999. From what I found this indicates that WebKit cancelled some loading--which is weird because it doesn't look like anything is loading on the existing page. But adding a `stopLoading` did correct the problem, so...?

Added `stopLoading` to forward to just be safe--even though we weren't seeing any issues there.


https://github.com/user-attachments/assets/eac570e6-fa99-4ff7-baec-a8fb83cb3cc4

