### PR TITLE
Hook up open in new page action

### DIFF
--- a/lib/Sources/App/AppModel.swift
+++ b/lib/Sources/App/AppModel.swift
@@ -9,6 +9,7 @@ import Observation
 import Settings
 import SwiftUI
 import Tabs
+import WebKit
 import WebView
 
 @MainActor
@@ -42,9 +43,9 @@ public class AppModel {
             self.activePageModel = buildPageModel(tabIndex: tabIndex)
         }
 
-        tabsModel.openTab = { [weak self] tab in
+        tabsModel.openTab = { [weak self] tabModel in
             guard let self else { return }
-            self.activePageModel = buildPageModel(tabIndex: tab.index, initialUrl: tab.url)
+            self.activePageModel = buildPageModel(tabModel: tabModel)
         }
 
         Task {
@@ -61,7 +62,11 @@ public class AppModel {
         }
     }
 
-    private func buildPageModel(tabIndex: Int, initialUrl: URL? = nil) -> WebLoadingModel? {
+    private func buildPageModel(tabModel: TabModel) -> WebLoadingModel {
+        buildPageModel(tabIndex: tabModel.index, initialUrl: tabModel.url)
+    }
+
+    private func buildPageModel(tabIndex: Int, initialUrl: URL? = nil) -> WebLoadingModel {
         let navBarModel = buildNavModel(tabIndex: tabIndex)
         let freshPageModel = FreshPageModel(searchBarModel: navBarModel.searchBarModel)
         let loadingModel = WebLoadingModel(freshPageModel: freshPageModel, navBarModel: navBarModel)
@@ -116,23 +121,29 @@ public class AppModel {
 
     private func loadWebContainerModel(tab: Int, url: URL, navBarModel: NavBarModel) async -> WebContainerModel? {
         do {
-            return try await WebContainerModel.loadAsync(
-                selector: deviceSelector,
-                navBarModel: navBarModel,
-                webConfigLoader: webConfigLoader
-            ) { [messageProcessorFactory] config in
-                WebPageModel(
-                    tab: tab,
-                    url: url,
-                    config: config,
-                    messageProcessorFactory: messageProcessorFactory,
-                    navigator: navBarModel.navigator
-                )
-            }
+            let config = try await webConfigLoader.loadConfig()
+            return buildWebContainerModel(tab: tab, url: url, navBarModel: navBarModel, config: config)
         } catch {
             // TODO: navigate away due to failure and try again
             print("Unable to load \(error)")
             return nil
         }
+    }
+
+    private func buildWebContainerModel(tab: Int, url: URL, navBarModel: NavBarModel, config: WKWebViewConfiguration) -> WebContainerModel {
+        let webPageModel = WebPageModel(
+            tab: tab,
+            url: url,
+            config: config,
+            messageProcessorFactory: messageProcessorFactory,
+            navigator: navBarModel.navigator
+        )
+        webPageModel.launchNewPage = { [weak self] newUrl in
+            guard let self else { return }
+            let newTab = self.tabsModel.findOrCreateTab(for: newUrl)
+            let webLoadingModel = self.buildPageModel(tabModel: newTab)
+            self.activePageModel = webLoadingModel
+        }
+        return WebContainerModel(webPageModel: webPageModel, navBarModel: navBarModel, selector: deviceSelector)
     }
 }

--- a/lib/Sources/App/WebContainerModel.swift
+++ b/lib/Sources/App/WebContainerModel.swift
@@ -1,9 +1,7 @@
-import Bluetooth
 import DevicePicker
 import Observation
 import SwiftUI
 import WebView
-import WebKit
 
 @MainActor
 @Observable
@@ -28,16 +26,5 @@ public final class WebContainerModel {
                 selector.cancel()
             }
         )
-    }
-
-    static func loadAsync(
-        selector: DeviceSelector,
-        navBarModel: NavBarModel,
-        webConfigLoader: WebConfigLoader,
-        buildWebModel: @escaping (WKWebViewConfiguration) -> WebPageModel
-    ) async throws -> WebContainerModel {
-        let config = try await webConfigLoader.loadConfig()
-        let webPageModel = buildWebModel(config)
-        return .init(webPageModel: webPageModel, navBarModel: navBarModel, selector: selector)
     }
 }

--- a/lib/Sources/App/WebLoadingModel.swift
+++ b/lib/Sources/App/WebLoadingModel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 @MainActor
 @Observable
-public final class WebLoadingModel {
+public final class WebLoadingModel: Identifiable, Equatable {
     let freshPageModel: FreshPageModel
     let navBarModel: NavBarModel
     var webContainerModel: WebContainerModel?
@@ -21,5 +21,9 @@ public final class WebLoadingModel {
     var shouldShowFreshPageOverlay: Bool {
         guard let webContainerModel else { return true }
         return webContainerModel.webPageModel.isPerformingInitialContentLoad
+    }
+
+    nonisolated public static func == (lhs: WebLoadingModel, rhs: WebLoadingModel) -> Bool {
+        lhs.id == rhs.id
     }
 }

--- a/lib/Sources/App/WebLoadingView.swift
+++ b/lib/Sources/App/WebLoadingView.swift
@@ -19,6 +19,7 @@ struct WebLoadingView: View {
                 FreshPageView(model: model.freshPageModel)
             }
         }
+        .id(model.id)
         .animation(.easeInOut, value: model.shouldShowFreshPageOverlay)
     }
 }

--- a/lib/Sources/Tabs/TabGridModel.swift
+++ b/lib/Sources/Tabs/TabGridModel.swift
@@ -8,6 +8,10 @@ public final class TabGridModel {
     private let store: CodableStorage?
     private var tabs: [Int: TabModel]
 
+    private var nextIndex: Int {
+        (tabs.keys.max() ?? 0) + 1
+    }
+
     public var openTab: (TabModel) -> Void = { _ in }
     public var openNewTab: (Int) -> Void = { _ in }
 
@@ -43,7 +47,6 @@ public final class TabGridModel {
     }
 
     func newTabButtonTapped() {
-        let nextIndex = (tabs.keys.max() ?? 0) + 1
         openNewTab(nextIndex)
     }
 
@@ -56,6 +59,19 @@ public final class TabGridModel {
         if let urls: [URL] = try? await store?.load(for: .tabURLsKey) {
             self.tabs = Self.urlsToTabs(urls)
         }
+    }
+
+    public func findOrCreateTab(for url: URL) -> TabModel {
+        if let tabModel = sortedTabs.first(where: { $0.url == url }) {
+            return tabModel
+        }
+        return createTab(for: url)
+    }
+
+    public func createTab(for url: URL) -> TabModel {
+        let newTabModel = TabModel(index: nextIndex, url: url)
+        update(url: url, at: newTabModel.index)
+        return newTabModel
     }
 
     // TODO: store a thumbnail image for the rendered URL content

--- a/lib/Sources/Tabs/TabGridModel.swift
+++ b/lib/Sources/Tabs/TabGridModel.swift
@@ -77,7 +77,8 @@ public final class TabGridModel {
         return createTab(for: url)
     }
 
-    public func createTab(for url: URL) -> TabModel {
+    @discardableResult
+    private func createTab(for url: URL) -> TabModel {
         let newTabModel = TabModel(index: nextIndex, url: url)
         update(url: url, at: newTabModel.index)
         return newTabModel

--- a/lib/Sources/WebView/Coordinator+Navigation.swift
+++ b/lib/Sources/WebView/Coordinator+Navigation.swift
@@ -1,10 +1,14 @@
 import Foundation
+import OSLog
 import WebKit
+
+private let log = Logger(subsystem: "WebView", category: "WKNavigationDelegate")
 
 extension Coordinator: WKNavigationDelegate {
 
     // Request has been sent to the web server and we are ready to start receiving a response
     public func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+        log.debug("didStartProvisionalNavigation navigation=\(navigation) \(self.extraDebugInfo)")
         if let url = navigatingToUrl {
             didBeginNavigation(to: url, in: webView)
         }
@@ -12,36 +16,42 @@ extension Coordinator: WKNavigationDelegate {
 
     // Started receiving a response and will attempt to begin parsing the HTML
     public func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+        log.debug("didCommitNavigation navigation=\(navigation) \(self.extraDebugInfo)")
         didCommitNavigation(in: webView)
     }
 
     // All data received and if DOM is not already complete it will be very soon
     public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        log.debug("didFinishNavigation navigation=\(navigation) \(self.extraDebugInfo)")
         if let url = navigatingToUrl {
             didFinishNavigation(to: url, in: webView)
         }
         navigatingToUrl = nil
     }
 
+    // WARNING: non-nullable navigationAction.sourceFrame property may actually be nil here http://www.openradar.appspot.com/FB9877215
     public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction) async -> WKNavigationActionPolicy {
-        if let url = navigationAction.request.url {
-            navigatingToUrl = url
-        } else {
-            navigatingToUrl = nil
+        navigatingToUrl = navigationAction.request.url
+        if navigationAction.isOpeningNewTab {
+            log.debug("decidePolicyForNavigationAction wants to open a new tab")
         }
+        log.debug("decidePolicyForNavigationAction action=\(navigationAction) \(self.extraDebugInfo) policy=allow")
         return .allow
     }
 
     public func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse) async -> WKNavigationResponsePolicy {
+        log.debug("decidePolicyForNavigationResponse response=\(navigationResponse) \(self.extraDebugInfo) policy=allow")
         return .allow
     }
 
     public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: any Error) {
+        log.debug("didFailProvisionalNavigation navigation=\(navigation) \(self.extraDebugInfo) error=\(error)")
         let document = errorDocument(error: error, url: navigatingToUrl)
         redirectDueToError(to: document)
     }
 
     public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: any Error) {
+        log.debug("didFailNavigation navigation=\(navigation) \(self.extraDebugInfo) error=\(error)")
         let document = errorDocument(error: error, url: navigatingToUrl)
         redirectDueToError(to: document)
     }
@@ -55,4 +65,16 @@ private func errorDocument(error: any Error, url: URL?) -> SimpleHtmlDocument {
     }
     document.addElement(.p, error.localizedDescription)
     return document
+}
+
+private extension WKNavigationAction {
+    var isOpeningNewTab: Bool {
+        targetFrame == nil && sourceFrame.isMainFrame && navigationType == .linkActivated
+    }
+}
+
+extension Coordinator {
+    var extraDebugInfo: String {
+        "navigatingToUrl=\(navigatingToUrl?.absoluteString ?? "nil") tab=\(tab)"
+    }
 }

--- a/lib/Sources/WebView/Coordinator+UI.swift
+++ b/lib/Sources/WebView/Coordinator+UI.swift
@@ -1,13 +1,15 @@
 import Foundation
+import OSLog
 import WebKit
+
+private let log = Logger(subsystem: "WebView", category: "WKUIDelegate")
 
 extension Coordinator: WKUIDelegate {
 
     public func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
-        if let url = navigationAction.request.url {
-            print("TODO: open \(url) in a new tab")
-        }
-        navigatingToUrl = nil
+        log.debug("createWebView navigationAction=\(navigationAction) \(self.extraDebugInfo)")
+        openLinkInNewTab(url: navigationAction.request.url)
         return nil
     }
+
 }

--- a/lib/Sources/WebView/Coordinator.swift
+++ b/lib/Sources/WebView/Coordinator.swift
@@ -13,12 +13,17 @@ public class Coordinator: NSObject {
 
     var navigatingToUrl: URL?
 
+    // Used for debug logging:
+    var tab: Int {
+        viewModel?.tab ?? -1
+    }
+
     override init() {}
 
     func initialize(webView: WKWebView, model: WebPageModel) {
         self.viewModel = model
         self.messageProcessorFactory = model.messageProcessorFactory
-        self.contextId = JsContextIdentifier(tab: model.tab, url: model.url)
+        self.contextId = model.contextId
 
         webView.customUserAgent = model.customUserAgent
         webView.navigationDelegate = self
@@ -76,6 +81,15 @@ public class Coordinator: NSObject {
     func redirectDueToError(to document: SimpleHtmlDocument) {
         navigatingToUrl = nil
         viewModel?.navigator.redirect(to: document)
+    }
+
+    func openLinkInNewTab(url: URL?) {
+        guard let launchNewPage = viewModel?.launchNewPage, let url else {
+            return
+        }
+        navigatingToUrl = nil
+        viewModel?.navigator.stopLoading()
+        launchNewPage(url)
     }
 }
 

--- a/lib/Sources/WebView/WebPageModel.swift
+++ b/lib/Sources/WebView/WebPageModel.swift
@@ -6,7 +6,7 @@ import WebKit
 
 @MainActor
 @Observable
-public class WebPageModel {
+public class WebPageModel: Identifiable {
     @ObservationIgnored
     private var kvoStore: [NSKeyValueObservation] = []
 
@@ -20,6 +20,8 @@ public class WebPageModel {
     public var isPerformingInitialContentLoad: Bool = true
 
     public let navigator: WebNavigator
+
+    public var launchNewPage: ((URL) -> Void)?
 
     let messageProcessorFactory: JsMessageProcessorFactory
 
@@ -47,6 +49,12 @@ public class WebPageModel {
 
     public func loadNewPage(url: URL) {
         self.url = url
+    }
+
+    func createWebView() -> WKWebView {
+         let webView = WKWebView(frame: .zero, configuration: config)
+         webView.allowsBackForwardNavigationGestures = true
+         return webView
     }
 
     func didInitializeWebView(_ webView: WKWebView) {

--- a/lib/Sources/WebView/WebPageView.swift
+++ b/lib/Sources/WebView/WebPageView.swift
@@ -17,6 +17,7 @@ public struct WebPageView: View {
 
     public var body: some View {
         _WebPageView(model: model, scrollView: $scrollView)
+            .id(model.id)
             .preference(key: WebPageScrollViewKey.self, value: scrollView)
     }
 
@@ -31,8 +32,7 @@ public struct WebPageView: View {
         }
 
         func makeUIView(context: Context) -> WKWebView {
-            let webView = WKWebView(frame: .zero, configuration: model.config)
-            webView.allowsBackForwardNavigationGestures = true
+            let webView = model.createWebView()
             context.coordinator.initialize(webView: webView, model: model)
             Task { @MainActor in
                 scrollView = webView.scrollView


### PR DESCRIPTION
Tried a ton of things and arrived at this pretty basic form of "open link in new tab".

When a link on a page asks for a new window we create a new tab, or re-open an existing tab if there is a match. This relies on the callback from `WKUIDelegate`, but we do not buy into the intended mechanism of spinning out a new view from within the delgate as that does not gel with the current architecture, and is especially awkward when using the SwiftUI `UIViewRepresentable` wrapper. So we just use it as a trigger.

Note that many web pages redirect away from the source link URL when first loaded. Detecting that correctly is pretty complicated, so in those (very common) cases we will end up with duplicate tabs being spawned for these links.

This feature also does not attempt to implement a back button that closes the new tab. Turns out that a "normal feeling" implementation like what Safari does is also pretty complicated. This is mitigated slightly by #111 but could do with a lot of improvement.

This feature also does not attempt to animate the new-tab transition. Everything I tried here looked worse, and it looks like it would take some major refactoring to build in some graceful tab transitions.
