### PR TITLE
Allow `optionalServices` with `acceptAllDevices`

### DIFF
--- a/lib/Sources/BluetoothAction/Options+Decode.swift
+++ b/lib/Sources/BluetoothAction/Options+Decode.swift
@@ -30,7 +30,7 @@ extension Options {
         }
 
         if acceptAllDevices == true {
-            guard filters == nil && exclusionFilters == nil && optionalServices == nil && optionalManufacturerData == nil else {
+            guard filters == nil && exclusionFilters == nil && optionalManufacturerData == nil else {
                 throw OptionsError.invalidInput("Cannot set acceptAllDevices to true if other options are provided")
             }
         }

--- a/lib/Tests/BluetoothEngineTests/Options+DecodeTests.swift
+++ b/lib/Tests/BluetoothEngineTests/Options+DecodeTests.swift
@@ -584,6 +584,19 @@ struct Options_DecodeTests {
         }
     }
 
+    @Test
+    func decode_acceptAllDeviceWithOptionalServices_isAllowed() {
+        // { acceptAllDevices: true, optionalServices:[E] }
+        let web_bluetooth_options = ["acceptAllDevices": JsType.bridge(true), "optionalServices": JsType.bridge([uuid_3.uuidString])]
+
+        #expect(throws: Never.self) {
+            let result = try sut.decode(from: web_bluetooth_options)
+
+            #expect(result.acceptAllDevices == true)
+            #expect(result.optionalServices == [uuid_3])
+        }
+    }
+
     private func expect(filters: [Options.Filter]?, expectedCount: Int) {
         #expect(filters != nil)
         #expect(filters?.count == expectedCount)


### PR DESCRIPTION
`optionalServices` should be allowed to be used when `acceptAllDevices` is `true` (is done in the [Web Bluetooth / Write Descriptor Sample](https://googlechrome.github.io/samples/web-bluetooth/write-descriptor.html)).

In the [Web Bluetooth spec](https://webbluetoothcg.github.io/web-bluetooth/#device-discovery):

![Screenshot 2025-02-26 at 4 33 54 PM](https://github.com/user-attachments/assets/fd055779-d8a6-460c-8f0d-99ec3676c67e)
