### PR TITLE
Fix bug around activePageModel stack initialization

### DIFF
--- a/lib/Sources/App/AppModel.swift
+++ b/lib/Sources/App/AppModel.swift
@@ -51,7 +51,9 @@ public class AppModel {
 
         tabsModel.restoreLastOpenedTab = { [weak self] in
             guard let self else { return }
-            self.activePageModel = self.previousActivePageModel
+            if let webPageModel = self.previousActivePageModel?.webContainerModel?.webPageModel {
+                self.activePageModel = self.buildPageModel(tabIndex: webPageModel.tab, initialUrl: webPageModel.url)
+            }
         }
 
         Task {


### PR DESCRIPTION
First implementation for restoring the last tab opened wasn't properly reinitializing the activePageModel stack. This PR fixes it.


https://github.com/user-attachments/assets/35bb9a07-f3ea-440f-843a-74fe53aa3001

