### PR TITLE
Select newest iOS simulator explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,6 @@ jobs:
       - uses: actions/checkout@v4
       - run: xcodes select
       - run: xcodebuild -version
+      - name: Install iOS 18.2 again to workaround bad runner config
+        run: xcodebuild -downloadPlatform iOS -buildVersion 18.2
       - run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
       - run: xcrun simctl list devices available iOS
       - run: xcodes select
       - run: xcodebuild -version
+      - name: Install iOS 18.2 again to workaround bad runner config
+        run: xcodebuild -downloadPlatform iOS -buildVersion 18.2
       - run: make build
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,8 @@ jobs:
     runs-on: [macOS-15]
     steps:
       - uses: actions/checkout@v4
-      - run: xcrun simctl list devices available
+      - run: xcrun simctl list runtimes
+      - run: xcrun simctl list devices available iOS
       - run: xcodes select
       - run: xcodebuild -version
       - run: make build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
       - run: xcrun simctl list devices available iOS
       - run: xcodes select
       - run: xcodebuild -version
-      - name: Install iOS 18.2 again to workaround bad runner config
-        run: xcodebuild -downloadPlatform iOS -buildVersion 18.2
       - run: make build
   test:
     name: Test
@@ -33,6 +31,4 @@ jobs:
       - uses: actions/checkout@v4
       - run: xcodes select
       - run: xcodebuild -version
-      - name: Install iOS 18.2 again to workaround bad runner config
-        run: xcodebuild -downloadPlatform iOS -buildVersion 18.2
       - run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
   test:
     name: Test
     runs-on: [macOS-15]
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - run: xcodes select

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
   test:
     name: Test
     runs-on: [macOS-15]
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - run: xcodes select


### PR DESCRIPTION
An attempt to fix the building issue by targeting the mast recent simulator version explicitly. My hunch is the action runners have older simulator runtimes referenced but the images are not mounted so they fail to boot.

_edit: GH support have confirmed that iOS 18.2 is offline for now and advise to use 18.3. But the problem is the builds still fail with an error "error:iOS 18.2 is not installed" when building against 18.3. The workaround for now is to force download 18.2 prior to each build._