### PR TITLE
Implement Bluetooth.getDevices and BluetoothDevice.watchAdvertisements

### DIFF
--- a/lib/Javascript/src/Bluetooth.ts
+++ b/lib/Javascript/src/Bluetooth.ts
@@ -37,15 +37,10 @@ export class Bluetooth extends EventTarget {
 
     constructor() {
         super();
-        this.addEventListener('availabilitychanged', (event) => {
-            this.onavailabilitychanged(event);
-        });
     }
 
-    // Alternative API to the availabilitychanged event listener
-    // https://webdocs.dev/en-us/docs/web/api/bluetooth/availabilitychanged_event
-    onavailabilitychanged = (event: ValueEvent<boolean>) => {
-    };
+    // TODO: https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes
+    // Events: advertisementreceived
 
     getAvailability = async (): Promise<boolean> => {
         const response = await bluetoothRequest<undefined, GetAvailabilityResponse>(

--- a/lib/Javascript/src/Bluetooth.ts
+++ b/lib/Javascript/src/Bluetooth.ts
@@ -21,7 +21,11 @@ type RequestDeviceResponse = {
     name?: string;
 }
 
-export const createDevice = (uuid: string, name?: string): BluetoothDevice => {
+export const getOrCreateDevice = (uuid: string, name?: string): BluetoothDevice => {
+    const existing = store.getDevice(uuid);
+    if (existing) {
+        return existing;
+    }
     const device = new BluetoothDevice(uuid, name);
     store.addDevice(device);
     return device;
@@ -54,7 +58,7 @@ export class Bluetooth extends EventTarget {
         const response = await bluetoothRequest<undefined, RequestDeviceResponse[]>(
             'getDevices'
         );
-        return response.map(device => createDevice(device.uuid, device.name));
+        return response.map(device => getOrCreateDevice(device.uuid, device.name));
     }
 
     requestDevice = async (options?: Options): Promise<BluetoothDevice> => {
@@ -62,7 +66,7 @@ export class Bluetooth extends EventTarget {
             'requestDevice',
             { options: options }
         );
-        return createDevice(response.uuid, response.name);
+        return getOrCreateDevice(response.uuid, response.name);
     }
 
     requestLEScan = async (options?: BluetoothLEScanOptions): Promise<BluetoothLEScan> => {

--- a/lib/Javascript/src/BluetoothAdvertisingEvent.ts
+++ b/lib/Javascript/src/BluetoothAdvertisingEvent.ts
@@ -1,10 +1,9 @@
 // https://webbluetoothcg.github.io/web-bluetooth/#advertising-events
 
-import { createDevice } from "./Bluetooth";
+import { getOrCreateDevice } from "./Bluetooth";
 import { BluetoothDevice } from "./BluetoothDevice";
 import { base64ToDataView } from "./Data";
 import type { TargetedEvent } from "./EventSink";
-import { store } from "./Store";
 
 export interface BluetoothAdvertisingEventInit extends EventInit {
     device: BluetoothDevice;
@@ -68,10 +67,7 @@ type AdvertisementEventPayload = {
 // Side effect: creates a new device if it doesn't exist and adds it to the store
 export const convertToAdvertisingEvent = (event: TargetedEvent): BluetoothAdvertisingEvent => {
     const payload: AdvertisementEventPayload = event.data;
-    let device = store.getDevice(payload.device.uuid);
-    if (!device) {
-        device = createDevice(payload.device.uuid, payload.device.name);
-    }
+    const device = getOrCreateDevice(payload.device.uuid, payload.device.name);
     let manufacturerData = new Map<number, DataView>();
     if (payload.advertisement.manufacturerData) {
         manufacturerData.set(

--- a/lib/Javascript/src/BluetoothDevice.ts
+++ b/lib/Javascript/src/BluetoothDevice.ts
@@ -1,4 +1,13 @@
 import { BluetoothRemoteGATTServer } from "./BluetoothRemoteGATTServer";
+import { EmptyObject } from "./EmptyObject";
+import { store } from "./Store";
+import { bluetoothRequest } from "./WebKit";
+
+type ForgetDeviceRequest = {
+    uuid: string;
+}
+
+type ForgetDeviceResponse = EmptyObject;
 
 // https://developer.mozilla.org/en-US/docs/Web/API/BluetoothDevice
 export class BluetoothDevice extends EventTarget {
@@ -13,5 +22,12 @@ export class BluetoothDevice extends EventTarget {
         this.gatt = new BluetoothRemoteGATTServer(this);
     }
 
-    // TODO:
+    forget = async (): Promise<void> => {
+        await bluetoothRequest<ForgetDeviceRequest, ForgetDeviceResponse>(
+            'forgetDevice',
+            { uuid: this.id }
+        );
+        store.removeDevice(this.id);
+        return;
+    }
 }

--- a/lib/Javascript/src/BluetoothDevice.ts
+++ b/lib/Javascript/src/BluetoothDevice.ts
@@ -9,18 +9,40 @@ type ForgetDeviceRequest = {
 
 type ForgetDeviceResponse = EmptyObject;
 
+type WatchAdvertisementsRequest = {
+    uuid: string;
+    enable: boolean;
+}
+
+type WatchAdvertisementsResponse = EmptyObject;
+
+type WatchAdvertisementsOptions = {
+    signal?: AbortSignal;
+}
+
 // https://developer.mozilla.org/en-US/docs/Web/API/BluetoothDevice
 export class BluetoothDevice extends EventTarget {
     id: string;
     name: string | undefined;
     gatt: BluetoothRemoteGATTServer;
+    watchingAdvertisements: boolean;
 
     constructor(id: string, name?: string) {
         super();
         this.id = id;
         this.name = name;
         this.gatt = new BluetoothRemoteGATTServer(this);
+        this.watchingAdvertisements = false;
     }
+
+    // TODO: https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes
+    // Events:
+    // advertisementreceived
+    // gattserverdisconnected
+    // characteristicvaluechanged
+    // serviceadded
+    // servicechanged
+    // serviceremoved
 
     forget = async (): Promise<void> => {
         await bluetoothRequest<ForgetDeviceRequest, ForgetDeviceResponse>(
@@ -28,6 +50,29 @@ export class BluetoothDevice extends EventTarget {
             { uuid: this.id }
         );
         store.removeDevice(this.id);
-        return;
+    }
+
+    watchAdvertisements = async (options?: WatchAdvertisementsOptions): Promise<void> => {
+        let signal = options?.signal;
+        if (signal) {
+            if (signal.aborted) {
+                await this._toggleWatchingAdvertisements(false);
+                return;
+            }
+            signal.addEventListener('abort', () => {
+                this._toggleWatchingAdvertisements(false);
+            });
+        }
+        if (!this.watchingAdvertisements) {
+            await this._toggleWatchingAdvertisements(true);
+        }
+    }
+
+    _toggleWatchingAdvertisements = async (isWatching: boolean): Promise<void> => {
+        await bluetoothRequest<WatchAdvertisementsRequest, WatchAdvertisementsResponse>(
+            'watchAdvertisements',
+            { uuid: this.id, enable: isWatching }
+        );
+        this.watchingAdvertisements = isWatching;
     }
 }

--- a/lib/Javascript/src/EventSink.ts
+++ b/lib/Javascript/src/EventSink.ts
@@ -41,5 +41,10 @@ export const processEvent = (event: TargetedEvent) => {
 
     for (const target of targets) {
         target.dispatchEvent(eventToSend);
+        // Invoke the on<event> handler if it exists
+        const handler = target['on' + eventToSend.type];
+        if (handler) {
+            handler(eventToSend);
+        }
     }
 }

--- a/lib/Javascript/src/EventSink.ts
+++ b/lib/Javascript/src/EventSink.ts
@@ -18,12 +18,17 @@ export const processEvent = (event: TargetedEvent) => {
         targets.push(globalThis.topaz.bluetooth);
     }
 
-    if (event.name === 'gattserverdisconnected') {
-        // Forward this to the specific device
-        const device = store.getDevice(event.id);
-        if (device) {
-            targets.push(device);
+    const pushDeviceTarget = () => {
+        if (event.id !== 'bluetooth') {
+            const device = store.getDevice(event.id);
+            if (device) {
+                targets.push(device);
+            }
         }
+    }
+
+    if (event.name === 'gattserverdisconnected') {
+        pushDeviceTarget();
     } else if (event.name === 'characteristicvaluechanged') {
         // Decode the data payload, update the store, and forward event to the specific characteristic
         const data = base64ToDataView(event.data);
@@ -32,6 +37,7 @@ export const processEvent = (event: TargetedEvent) => {
         eventToSend = new ValueEvent(event.name, { value: data });
     } else if (event.name === 'advertisementreceived') {
         eventToSend = convertToAdvertisingEvent(event);
+        pushDeviceTarget();
     }
 
     if (!eventToSend) {

--- a/lib/Javascript/src/Store.ts
+++ b/lib/Javascript/src/Store.ts
@@ -43,11 +43,17 @@ class Store {
     }
 
     addDevice = (device: BluetoothDevice) => {
-        const deviceRecord = this.#devices.get(device.id);
+        this.removeDevice(device.id);
+        this.#devices.set(device.id, { uuid: device.id, device, services: new Map() });
+    }
+
+    removeDevice = (uuid: string): BluetoothDevice | undefined => {
+        const deviceRecord = this.#devices.get(uuid);
         if (deviceRecord) {
             // Perform any cleanup necessary here
         }
-        this.#devices.set(device.id, { uuid: device.id, device, services: new Map() });
+        this.#devices.delete(uuid);
+        return deviceRecord?.device;
     }
 
     getService = (deviceUuid: string, serviceUuid: string): BluetoothRemoteGATTService | undefined => {

--- a/lib/Sources/BluetoothAction/AdvertisementEvent+JsEvent.swift
+++ b/lib/Sources/BluetoothAction/AdvertisementEvent+JsEvent.swift
@@ -5,7 +5,7 @@ import JsMessage
 
 extension AdvertisementEvent {
     // https://webbluetoothcg.github.io/web-bluetooth/#advertising-events
-    func toJs() -> JsEvent {
+    func toJs(targetId: String) -> JsEvent {
         let jsAdvertisement: [String: JsConvertable] = [
             "uuids": peripheral.services.map { $0.uuid },
             "name": advertisement.localName ?? jsNull,
@@ -22,7 +22,7 @@ extension AdvertisementEvent {
             "advertisement": jsAdvertisement,
             "device": jsDevice,
         ]
-        return JsEvent(targetId: "bluetooth", eventName: "advertisementreceived", body: body)
+        return JsEvent(targetId: targetId, eventName: "advertisementreceived", body: body)
     }
 }
 

--- a/lib/Sources/BluetoothAction/Connect.swift
+++ b/lib/Sources/BluetoothAction/Connect.swift
@@ -32,6 +32,7 @@ struct Connector: BluetoothAction {
         if case .connected = peripheral.connectionState {
             return ConnectResponse()
         }
+        await state.rememberPeripheral(peripheral.id)
         _ = try await client.connect(peripheral)
         return ConnectResponse()
     }

--- a/lib/Sources/BluetoothAction/DiscoverDescriptors.swift
+++ b/lib/Sources/BluetoothAction/DiscoverDescriptors.swift
@@ -60,7 +60,7 @@ struct DiscoverDescriptorsResponse: JsMessageEncodable {
     let descriptors: [Descriptor]
 
     func toJsMessage() -> JsMessage.JsMessageResponse {
-        .body(descriptors.map { $0.uuid.uuidString.lowercased() })
+        .body(descriptors.map { $0.uuid })
     }
 }
 

--- a/lib/Sources/BluetoothAction/ForgetDevice.swift
+++ b/lib/Sources/BluetoothAction/ForgetDevice.swift
@@ -1,0 +1,36 @@
+import Bluetooth
+import BluetoothClient
+import BluetoothMessage
+import Foundation
+import JsMessage
+
+struct ForgetDeviceRequest: JsMessageDecodable {
+    let peripheralId: UUID
+
+    static func decode(from data: [String: JsType]?) -> Self? {
+        guard let uuid = data?["uuid"]?.string.flatMap(UUID.init(uuidString:)) else {
+            return nil
+        }
+        return .init(peripheralId: uuid)
+    }
+}
+
+struct ForgetDeviceResponse: JsMessageEncodable {
+    func toJsMessage() -> JsMessageResponse {
+        .body([:])
+    }
+}
+
+struct ForgetDevice: BluetoothAction {
+    let requiresReadyState: Bool = true
+    let request: ForgetDeviceRequest
+
+    init(request: ForgetDeviceRequest) {
+        self.request = request
+    }
+
+    func execute(state: BluetoothState, client: BluetoothClient) async throws -> ForgetDeviceResponse {
+        await state.forgetPeripheral(request.peripheralId)
+        return ForgetDeviceResponse()
+    }
+}

--- a/lib/Sources/BluetoothAction/GetDevices.swift
+++ b/lib/Sources/BluetoothAction/GetDevices.swift
@@ -17,7 +17,7 @@ struct GetDevicesResponse: JsMessageEncodable {
         .body(
             peripherals.map { (id, name) in
                 [
-                    "uuid": id.uuidString,
+                    "uuid": id,
                     "name": name,
                 ]
             }

--- a/lib/Sources/BluetoothAction/GetDevices.swift
+++ b/lib/Sources/BluetoothAction/GetDevices.swift
@@ -1,0 +1,43 @@
+import Bluetooth
+import BluetoothClient
+import BluetoothMessage
+import Foundation
+import JsMessage
+
+struct GetDevicesRequest: JsMessageDecodable {
+    static func decode(from data: [String: JsType]?) -> Self? {
+        return .init()
+    }
+}
+
+struct GetDevicesResponse: JsMessageEncodable {
+    let peripherals: [(id: UUID, name: JsConvertable?)]
+
+    func toJsMessage() -> JsMessageResponse {
+        .body(
+            peripherals.map { (id, name) in
+                [
+                    "uuid": id.uuidString,
+                    "name": name,
+                ]
+            }
+        )
+    }
+}
+
+struct GetDevices: BluetoothAction {
+    let requiresReadyState: Bool = true
+    let request: GetDevicesRequest
+
+    init(request: GetDevicesRequest) {
+        self.request = request
+    }
+
+    func execute(state: BluetoothState, client: BluetoothClient) async throws -> GetDevicesResponse {
+        let uuids = await state.getKnownPeripheralIdentifiers()
+        let peripherals = await client.getPeripherals(withIdentifiers: uuids)
+        return GetDevicesResponse(peripherals: peripherals.map { peripheral in
+            (id: peripheral.id, name: peripheral.name)
+        })
+    }
+}

--- a/lib/Sources/BluetoothAction/Message+Action.swift
+++ b/lib/Sources/BluetoothAction/Message+Action.swift
@@ -13,6 +13,8 @@ extension Message {
         switch action {
         case .getAvailability:
             return Availability.create(from: self)
+        case .getDevices:
+            return GetDevices.create(from: self)
         case .requestDevice:
             return RequestDeviceRequest.decode(from: self).map {
                 RequestDevice(request: $0, selector: selector)

--- a/lib/Sources/BluetoothAction/Message+Action.swift
+++ b/lib/Sources/BluetoothAction/Message+Action.swift
@@ -30,7 +30,9 @@ extension Message {
         case .forgetDevice:
             return ForgetDevice.create(from: self)
         case .watchAdvertisements:
-            return WatchAdvertisements.create(from: self)
+            return WatchAdvertisementsRequest.decode(from: self).map {
+                WatchAdvertisements(request: $0, jsEventForwarder: jsEventForwarder)
+            }
 
         // GATT Server
         case .connect:

--- a/lib/Sources/BluetoothAction/Message+Action.swift
+++ b/lib/Sources/BluetoothAction/Message+Action.swift
@@ -11,6 +11,8 @@ extension Message {
         jsEventForwarder: JsEventForwarder
     ) -> Result<any BluetoothAction, Error> {
         switch action {
+
+        // General
         case .getAvailability:
             return Availability.create(from: self)
         case .getDevices:
@@ -23,26 +25,40 @@ extension Message {
             return RequestLEScanRequest.decode(from: self).map {
                 RequestLEScan(request: $0, jsEventForwarder: jsEventForwarder)
             }
+
+        // BluetoothDevice
+        case .forgetDevice:
+            return ForgetDevice.create(from: self)
+        case .watchAdvertisements:
+            return WatchAdvertisements.create(from: self)
+
+        // GATT Server
         case .connect:
             return Connector.create(from: self)
         case .disconnect:
             return Disconnector.create(from: self)
         case .discoverServices:
             return DiscoverServices.create(from: self)
+
+        // GATT Service
         case .discoverCharacteristics:
             return DiscoverCharacteristics.create(from: self)
+
+        // GATT Characteristic
         case .discoverDescriptors:
             return DiscoverDescriptors.create(from: self)
         case .readCharacteristic:
             return ReadCharacteristic.create(from: self)
         case .writeCharacteristic:
             return WriteCharacteristic.create(from: self)
-        case .readDescriptor:
-            return ReadDescriptor.create(from: self)
         case .startNotifications:
             return StartNotifications.create(from: self)
         case .stopNotifications:
             return StopNotifications.create(from: self)
+
+        // GATT Descriptor
+        case .readDescriptor:
+            return ReadDescriptor.create(from: self)
         }
     }
 }

--- a/lib/Sources/BluetoothAction/RequestDevice.swift
+++ b/lib/Sources/BluetoothAction/RequestDevice.swift
@@ -23,7 +23,7 @@ struct RequestDeviceResponse: JsMessageEncodable {
 
     func toJsMessage() -> JsMessage.JsMessageResponse {
         .body([
-            "uuid": peripheralId.uuidString,
+            "uuid": peripheralId,
             "name": name,
         ])
     }

--- a/lib/Sources/BluetoothAction/RequestLEScan.swift
+++ b/lib/Sources/BluetoothAction/RequestLEScan.swift
@@ -105,10 +105,10 @@ struct RequestLEScan: BluetoothAction {
                 guard !Task.isCancelled else { return }
                 // TODO: Potential optimization: keep track of these devices and discard them if never connected after scanning
                 await state.putPeripheral(event.peripheral)
-                await jsEventForwarder.forwardEvent(event.toJs())
+                await jsEventForwarder.forwardEvent(event.toJs(targetId: "bluetooth"))
             }
         }
-        let scanTask = ScanTask(id: scanId, scan: activeScan, task: task)
+        let scanTask = ScanTask(id: scanId, task: task)
         await state.addScanTask(scanTask)
         return .start(id: scanId, scan: activeScan)
     }

--- a/lib/Sources/BluetoothAction/WatchAdvertisements.swift
+++ b/lib/Sources/BluetoothAction/WatchAdvertisements.swift
@@ -1,0 +1,81 @@
+import Bluetooth
+import BluetoothClient
+import BluetoothMessage
+import Foundation
+import JsMessage
+
+struct WatchAdvertisementsRequest: JsMessageDecodable {
+    let enable: Bool
+    let peripheralId: UUID
+
+    static func decode(from data: [String: JsType]?) -> Self? {
+        guard let enable = data?["enable"]?.number?.boolValue else {
+            return nil
+        }
+        guard let uuid = data?["uuid"]?.string.flatMap(UUID.init(uuidString:)) else {
+            return nil
+        }
+        return .init(enable: enable, peripheralId: uuid)
+    }
+}
+
+struct WatchAdvertisementsResponse: JsMessageEncodable {
+    func toJsMessage() -> JsMessageResponse {
+        .body([:])
+    }
+}
+
+struct WatchAdvertisements: BluetoothAction {
+    let requiresReadyState: Bool = true
+    let request: WatchAdvertisementsRequest
+    let jsEventForwarder: JsEventForwarder
+
+    init(request: WatchAdvertisementsRequest) {
+        self.request = request
+        self.jsEventForwarder = JsEventForwarder { _ in }
+    }
+
+    init(request: WatchAdvertisementsRequest, jsEventForwarder: JsEventForwarder) {
+        self.request = request
+        self.jsEventForwarder = jsEventForwarder
+    }
+
+    func execute(state: BluetoothState, client: BluetoothClient) async throws -> WatchAdvertisementsResponse {
+        if request.enable {
+            await executeStart(state: state, client: client)
+        } else {
+            await executeStop(state: state)
+        }
+        return WatchAdvertisementsResponse()
+    }
+
+    private func executeStart(state: BluetoothState, client: BluetoothClient) async {
+        let task = Task { [jsEventForwarder] in
+            // TODO: options for this device only, but combined with others?
+            let scanner = await client.scan(options: nil)
+            defer {
+                // TODO: only cancel if no other watchers
+                scanner.cancel()
+            }
+            for await event in scanner.advertisements {
+                guard !Task.isCancelled else { return }
+                await jsEventForwarder.forwardEvent(event.toJs())
+            }
+        }
+        // TODO: need a different kind of scan for this one
+        let activeScan = BluetoothLEScan(
+            filters: [.init(name: "")],
+            keepRepeatedDevices: false,
+            acceptAllAdvertisements: false,
+            active: true
+        )
+        let scanTask = ScanTask(id: request.peripheralId.uuidString, scan: activeScan, task: task)
+        await state.addScanTask(scanTask)
+    }
+
+    private func executeStop(state: BluetoothState) async {
+        if let scanTask = await state.removeScanTask(id: request.peripheralId.uuidString) {
+            scanTask.cancel()
+        }
+    }
+}

--- a/lib/Sources/BluetoothClient/BluetoothClient.swift
+++ b/lib/Sources/BluetoothClient/BluetoothClient.swift
@@ -14,6 +14,7 @@ public protocol BluetoothClient: Sendable {
     func scan(options: Options?) async -> BluetoothScanner
 
     func systemState() async throws -> SystemStateEvent
+    func getPeripherals(withIdentifiers uuids: [UUID]) async -> [Peripheral]
     func connect(_ peripheral: Peripheral) async throws -> PeripheralEvent
     func disconnect(_ peripheral: Peripheral) async throws -> PeripheralEvent
     func discoverServices(_ peripheral: Peripheral, filter: ServiceDiscoveryFilter) async throws -> ServiceDiscoveryEvent

--- a/lib/Sources/BluetoothClient/Mocks/MockClient.swift
+++ b/lib/Sources/BluetoothClient/Mocks/MockClient.swift
@@ -13,6 +13,7 @@ public struct MockBluetoothClient: BluetoothClient {
     public var onCancelPendingRequests: @Sendable () async -> Void
     public var onScan: @Sendable (_ options: Options?) async -> BluetoothScanner
     public var onSystemState: @Sendable () async throws -> SystemStateEvent
+    public var onGetPeripherals: @Sendable (_ uuids: [UUID]) async -> [Peripheral]
     public var onConnect: @Sendable (_ peripheral: Peripheral) async throws -> PeripheralEvent
     public var onDisconnect: @Sendable (_ peripheral: Peripheral) async throws -> PeripheralEvent
     public var onDiscoverServices: @Sendable (_ peripheral: Peripheral, _ filter: ServiceDiscoveryFilter) async throws -> ServiceDiscoveryEvent
@@ -34,6 +35,7 @@ public struct MockBluetoothClient: BluetoothClient {
         self.onCancelPendingRequests = { fatalError("Not implemented") }
         self.onScan = { _ in fatalError("Not implemented") }
         self.onSystemState = { fatalError("Not implemented") }
+        self.onGetPeripherals = { _ in fatalError("Not implemented") }
         self.onConnect = { _ in fatalError("Not implemented") }
         self.onDisconnect = { _ in fatalError("Not implemented") }
         self.onDiscoverServices = { _, _ in fatalError("Not implemented") }
@@ -71,6 +73,10 @@ public struct MockBluetoothClient: BluetoothClient {
 
     public func systemState() async throws -> SystemStateEvent {
         try await onSystemState()
+    }
+
+    public func getPeripherals(withIdentifiers uuids: [UUID]) async -> [Peripheral] {
+        await onGetPeripherals(uuids)
     }
 
     public func connect(_ peripheral: Peripheral) async throws -> PeripheralEvent {

--- a/lib/Sources/BluetoothMessage/BluetoothState.swift
+++ b/lib/Sources/BluetoothMessage/BluetoothState.swift
@@ -56,6 +56,20 @@ public actor BluetoothState {
         return peripheral
     }
 
+    public func rememberPeripheral(_ uuid: UUID) {
+        // TODO: persist known peripheral identifier
+    }
+
+    public func forgetPeripheral(_ uuid: UUID) {
+        self.peripherals.removeValue(forKey: uuid)
+        // TODO: un-persist known peripheral identifier
+    }
+
+    public func getKnownPeripheralIdentifiers() -> [UUID] {
+        // TODO: load peripheral identifiers from persistence
+        return Array(self.peripherals.keys)
+    }
+
     public func getService(peripheralId uuid: UUID, serviceId: UUID) throws -> Service {
         guard let service = try getPeripheral(uuid).services.first(where: { $0.uuid == serviceId }) else {
             throw BluetoothError.noSuchService(serviceId)

--- a/lib/Sources/BluetoothMessage/Message.swift
+++ b/lib/Sources/BluetoothMessage/Message.swift
@@ -12,6 +12,7 @@ public struct Message {
     public enum Action: String, CaseIterable {
         // General
         case getAvailability
+        case getDevices
         case requestDevice
         case requestLEScan
 

--- a/lib/Sources/BluetoothMessage/Message.swift
+++ b/lib/Sources/BluetoothMessage/Message.swift
@@ -16,6 +16,10 @@ public struct Message {
         case requestDevice
         case requestLEScan
 
+        // BluetoothDevice
+        case forgetDevice
+        case watchAdvertisements
+
         // GATT Server
         case connect
         case disconnect

--- a/lib/Sources/BluetoothMessage/ScanTask.swift
+++ b/lib/Sources/BluetoothMessage/ScanTask.swift
@@ -3,16 +3,13 @@ import Foundation
 
 public struct ScanTask: Sendable {
     public let id: String
-    public let scan: BluetoothLEScan
     public let task: Task<(), Never>
 
     public init(
         id: String,
-        scan: BluetoothLEScan,
         task: Task<(), Never>
     ) {
         self.id = id
-        self.scan = scan
         self.task = task
     }
 

--- a/lib/Sources/BluetoothNative/Coordinator.swift
+++ b/lib/Sources/BluetoothNative/Coordinator.swift
@@ -82,6 +82,14 @@ class Coordinator: @unchecked Sendable {
         }
     }
 
+    func retrievePeripherals(withIdentifiers uuids: [UUID]) async -> [Peripheral] {
+        queue.sync {
+            self.manager?.retrievePeripherals(withIdentifiers: uuids) ?? []
+        }.map { peripheral in
+            peripheral.erase(locker: delegate.locker)
+        }
+    }
+
     func connect(peripheral: Peripheral) {
         queue.async {
             guard let native = peripheral.rawValue else { return }

--- a/lib/Sources/BluetoothNative/NativeClient.swift
+++ b/lib/Sources/BluetoothNative/NativeClient.swift
@@ -53,6 +53,10 @@ struct NativeBluetoothClient: BluetoothClient {
         }
     }
 
+    func getPeripherals(withIdentifiers uuids: [UUID]) async -> [Peripheral] {
+        await coordinator.retrievePeripherals(withIdentifiers: uuids)
+    }
+
     func connect(_ peripheral: Peripheral) async throws -> PeripheralEvent {
         try await server.awaitEvent(key: .peripheral(.connect, peripheral)) {
             coordinator.connect(peripheral: peripheral)

--- a/lib/Sources/WebView/Resources/Generated/BluetoothPolyfill.js
+++ b/lib/Sources/WebView/Resources/Generated/BluetoothPolyfill.js
@@ -688,7 +688,11 @@ const doRequestLEScan = async (options) => {
     return newScan;
 };
 
-const createDevice = (uuid, name) => {
+const getOrCreateDevice = (uuid, name) => {
+    const existing = store.getDevice(uuid);
+    if (existing) {
+        return existing;
+    }
     const device = new BluetoothDevice(uuid, name);
     store.addDevice(device);
     return device;
@@ -705,11 +709,11 @@ class Bluetooth extends EventTarget {
         };
         this.getDevices = async () => {
             const response = await bluetoothRequest('getDevices');
-            return response.map(device => createDevice(device.uuid, device.name));
+            return response.map(device => getOrCreateDevice(device.uuid, device.name));
         };
         this.requestDevice = async (options) => {
             const response = await bluetoothRequest('requestDevice', { options: options });
-            return createDevice(response.uuid, response.name);
+            return getOrCreateDevice(response.uuid, response.name);
         };
         this.requestLEScan = async (options) => {
             return doRequestLEScan(options);
@@ -736,10 +740,7 @@ class BluetoothAdvertisingEvent extends Event {
 }
 const convertToAdvertisingEvent = (event) => {
     const payload = event.data;
-    let device = store.getDevice(payload.device.uuid);
-    if (!device) {
-        device = createDevice(payload.device.uuid, payload.device.name);
-    }
+    const device = getOrCreateDevice(payload.device.uuid, payload.device.name);
     let manufacturerData = new Map();
     if (payload.advertisement.manufacturerData) {
         manufacturerData.set(payload.advertisement.manufacturerData.code, base64ToDataView(payload.advertisement.manufacturerData.data));

--- a/lib/Sources/WebView/Resources/Generated/BluetoothPolyfill.js
+++ b/lib/Sources/WebView/Resources/Generated/BluetoothPolyfill.js
@@ -416,8 +416,13 @@ class Store {
             return (_a = __classPrivateFieldGet(this, _Store_devices, "f").get(uuid)) === null || _a === void 0 ? void 0 : _a.device;
         };
         this.addDevice = (device) => {
-            __classPrivateFieldGet(this, _Store_devices, "f").get(device.id);
+            this.removeDevice(device.id);
             __classPrivateFieldGet(this, _Store_devices, "f").set(device.id, { uuid: device.id, device, services: new Map() });
+        };
+        this.removeDevice = (uuid) => {
+            const deviceRecord = __classPrivateFieldGet(this, _Store_devices, "f").get(uuid);
+            __classPrivateFieldGet(this, _Store_devices, "f").delete(uuid);
+            return deviceRecord === null || deviceRecord === void 0 ? void 0 : deviceRecord.device;
         };
         this.getService = (deviceUuid, serviceUuid) => {
             var _a, _b;
@@ -652,9 +657,33 @@ class BluetoothRemoteGATTServer {
 class BluetoothDevice extends EventTarget {
     constructor(id, name) {
         super();
+        this.forget = async () => {
+            await bluetoothRequest('forgetDevice', { uuid: this.id });
+            store.removeDevice(this.id);
+        };
+        this.watchAdvertisements = async (options) => {
+            let signal = options === null || options === void 0 ? void 0 : options.signal;
+            if (signal) {
+                if (signal.aborted) {
+                    await this._toggleWatchingAdvertisements(false);
+                    return;
+                }
+                signal.addEventListener('abort', () => {
+                    this._toggleWatchingAdvertisements(false);
+                });
+            }
+            if (!this.watchingAdvertisements) {
+                await this._toggleWatchingAdvertisements(true);
+            }
+        };
+        this._toggleWatchingAdvertisements = async (isWatching) => {
+            await bluetoothRequest('watchAdvertisements', { uuid: this.id, enable: isWatching });
+            this.watchingAdvertisements = isWatching;
+        };
         this.id = id;
         this.name = name;
         this.gatt = new BluetoothRemoteGATTServer(this);
+        this.watchingAdvertisements = false;
     }
 }
 
@@ -701,8 +730,6 @@ class Bluetooth extends EventTarget {
     constructor() {
         super();
         this.activeScans = [];
-        this.onavailabilitychanged = (event) => {
-        };
         this.getAvailability = async () => {
             const response = await bluetoothRequest('getAvailability');
             return response.isAvailable;
@@ -718,9 +745,6 @@ class Bluetooth extends EventTarget {
         this.requestLEScan = async (options) => {
             return doRequestLEScan(options);
         };
-        this.addEventListener('availabilitychanged', (event) => {
-            this.onavailabilitychanged(event);
-        });
     }
 }
 
@@ -773,11 +797,16 @@ const processEvent = (event) => {
     if (event.id === 'bluetooth') {
         targets.push(globalThis.topaz.bluetooth);
     }
-    if (event.name === 'gattserverdisconnected') {
-        const device = store.getDevice(event.id);
-        if (device) {
-            targets.push(device);
+    const pushDeviceTarget = () => {
+        if (event.id !== 'bluetooth') {
+            const device = store.getDevice(event.id);
+            if (device) {
+                targets.push(device);
+            }
         }
+    };
+    if (event.name === 'gattserverdisconnected') {
+        pushDeviceTarget();
     }
     else if (event.name === 'characteristicvaluechanged') {
         const data = base64ToDataView(event.data);
@@ -787,12 +816,17 @@ const processEvent = (event) => {
     }
     else if (event.name === 'advertisementreceived') {
         eventToSend = convertToAdvertisingEvent(event);
+        pushDeviceTarget();
     }
     if (!eventToSend) {
         eventToSend = new ValueEvent(event.name, { value: event.data });
     }
     for (const target of targets) {
         target.dispatchEvent(eventToSend);
+        const handler = target['on' + eventToSend.type];
+        if (handler) {
+            handler(eventToSend);
+        }
     }
 };
 

--- a/lib/Tests/BluetoothEngineTests/GetDevicesTests.swift
+++ b/lib/Tests/BluetoothEngineTests/GetDevicesTests.swift
@@ -1,0 +1,105 @@
+import Bluetooth
+@testable import BluetoothAction
+import BluetoothClient
+import BluetoothMessage
+import Foundation
+import JsMessage
+import Testing
+import XCTest
+
+extension Tag {
+    @Tag static var getDevices: Self
+}
+
+@Suite(.tags(.getDevices))
+struct GetDevicesResponseTests {
+    @Test
+    func toJsMessage_withZeroPeripherals_hasEmptyArrayBody() throws {
+        let sut = GetDevicesResponse(peripherals: [])
+        let jsMessage = sut.toJsMessage()
+        let body = try #require(jsMessage.extractBody(as: NSArray.self))
+        #expect(body == [])
+    }
+
+    @Test
+    func toJsMessage_withOnePeripheral_hasExpectedBody() throws {
+        let sut = GetDevicesResponse(peripherals: [(id: UUID(n: 0), name: "Slartibartfast")])
+        let jsMessage = sut.toJsMessage()
+        let body = try #require(jsMessage.extractBody(as: NSArray.self))
+        let responseDict0 = [
+            "uuid": "00000000-0000-0000-0000-000000000000",
+            "name": "Slartibartfast",
+        ]
+        #expect(body == [responseDict0])
+    }
+
+    @Test
+    func toJsMessage_withTwoPeripherals_hasExpectedBody() throws {
+        let sut = GetDevicesResponse(
+            peripherals: [
+                (id: UUID(n: 0), name: "Slarti"),
+                (id: UUID(n: 1), name: "Bartfast"),
+            ]
+        )
+        let jsMessage = sut.toJsMessage()
+        let body = try #require(jsMessage.extractBody(as: NSArray.self))
+        let responseDict0 = [
+            "uuid": "00000000-0000-0000-0000-000000000000",
+            "name": "Slarti",
+        ]
+        let responseDict1 = [
+            "uuid": "00000000-0000-0000-0000-000000000001",
+            "name": "Bartfast",
+        ]
+        #expect(body == [responseDict0, responseDict1])
+    }
+}
+
+@Suite(.tags(.getDevices))
+struct GetDevicesTests {
+    @Test
+    func execute_withClientProvidingOnePeripheral_respondsWithOneResult() async throws {
+        var client = MockBluetoothClient()
+        client.onGetPeripherals = { _ in
+            [FakePeripheral(id: UUID(n: 0))]
+        }
+        let sut = GetDevices(request: GetDevicesRequest())
+        let response = try await sut.execute(state: BluetoothState(), client: client)
+        let jsMessage = response.toJsMessage()
+        let body = try #require(jsMessage.extractBody(as: NSArray.self))
+        #expect(body.count == 1)
+    }
+
+    @Test
+    func execute_withOneActivePeripheral_requestsSamePeripheralFromClient() async throws {
+        let callbackExpectation = XCTestExpectation(description: "Client get peripherals")
+        var client = MockBluetoothClient()
+        client.onGetPeripherals = { uuids in
+            #expect(uuids == [UUID(n: 0)])
+            callbackExpectation.fulfill()
+            return []
+        }
+        let state = BluetoothState(peripherals: [FakePeripheral(id: UUID(n: 0))])
+        let sut = GetDevices(request: GetDevicesRequest())
+        _ = try await sut.execute(state: state, client: client)
+        let outcome = await XCTWaiter().fulfillment(of: [callbackExpectation], timeout: 1.0)
+        #expect(outcome == .completed)
+    }
+
+    @Test(.disabled("rememberPeripheral is not yet implemented"))
+    func execute_withOneRememberedPeripheral_requestsSamePeripheralFromClient() async throws {
+        let callbackExpectation = XCTestExpectation(description: "Client get peripherals")
+        var client = MockBluetoothClient()
+        client.onGetPeripherals = { uuids in
+            #expect(uuids == [UUID(n: 0)])
+            callbackExpectation.fulfill()
+            return []
+        }
+        let state = BluetoothState()
+        await state.rememberPeripheral(UUID(n: 0))
+        let sut = GetDevices(request: GetDevicesRequest())
+        _ = try await sut.execute(state: state, client: client)
+        let outcome = await XCTWaiter().fulfillment(of: [callbackExpectation], timeout: 1.0)
+        #expect(outcome == .completed)
+    }
+}

--- a/lib/Tests/BluetoothEngineTests/WatchAdvertisementsTests.swift
+++ b/lib/Tests/BluetoothEngineTests/WatchAdvertisementsTests.swift
@@ -1,0 +1,63 @@
+import Bluetooth
+@testable import BluetoothAction
+import BluetoothClient
+import BluetoothMessage
+import Foundation
+import JsMessage
+import Testing
+
+extension Tag {
+    @Tag static var watchAdvertisements: Self
+}
+
+@Suite(.tags(.watchAdvertisements))
+struct WatchAdvertisementsRequestTests {
+
+    @Test
+    func decode_withValidInputs_succeeds() {
+        let uuid = UUID(n: 0)
+        let body: [String: JsType] = [
+            "enable": .number(true),
+            "uuid": .string(uuid.uuidString),
+        ]
+        let request = WatchAdvertisementsRequest.decode(from: body)
+        #expect(request?.enable == true)
+        #expect(request?.peripheralId == uuid)
+    }
+
+    @Test
+    func decode_withEnableFlagMissing_isNil() {
+        let uuid = UUID(n: 0)
+        let body: [String: JsType] = [
+            "uuid": .string(uuid.uuidString),
+        ]
+        let request = WatchAdvertisementsRequest.decode(from: body)
+        #expect(request == nil)
+    }
+
+    @Test
+    func decode_withUuidMissing_isNil() {
+        let body: [String: JsType] = [
+            "enable": .number(true),
+        ]
+        let request = WatchAdvertisementsRequest.decode(from: body)
+        #expect(request == nil)
+    }
+
+    @Test
+    func decode_withInvalidUuid_isNil() {
+        let body: [String: JsType] = [
+            "enable": .number(true),
+            "uuid": .string("bananaman"),
+        ]
+        let request = WatchAdvertisementsRequest.decode(from: body)
+        #expect(request == nil)
+    }
+
+    @Test
+    func decode_withEmptyBody_isNil() {
+        let body: [String: JsType] = [:]
+        let request = WatchAdvertisementsRequest.decode(from: body)
+        #expect(request == nil)
+    }
+}


### PR DESCRIPTION
## getDevices

Attempts to instantiate all previously known devices from `BluetoothState` and them to the Js object graph before returning them.

The implementation for `Bluetooth.getDevices` calls into the `CBCentralManager.retrievePeripherals` to obtian existing `Peripheral` objects. The list of Uuids to request is take from the current list of known devices in `BluetoothState`.

There is placeholder code in `BluetoothState` to persist the known devices for inter-session retrieval as a future feature. For now we will only emit peripherals from the current memory state so these will be lost if the web page is closed.

## watchAdvertisements

The implementation for `BluetoothDevice.watchAdvertisements` operates identically to `requestLEScan` except the scanner is started with zero filters. We then emits only events that match the given peripheral. Core bluetooth does not give us an API to make than any more efficient unfortunately.

A futher limitation is that each invocation of `scanForPeripherals` clobbers any previous scanning arguments so mixing `watchAdvertisements` along with `requestLEScan` or `getDevice` may have unpredicatbale results.

## forgetDevice

Removes the device from `BluetoothState` and from the Js object graph.


Examples:

|Get & Forget Devices|Watch Advertisments|Watch & Connect|
|---|---|---|
|![Screenshot 2025-03-04 at 16 20 52](https://github.com/user-attachments/assets/365cc7bd-74e0-45df-8127-166f7d4f7f87)|![Screenshot 2025-03-04 at 16 18 44](https://github.com/user-attachments/assets/df32b310-15d0-479a-be12-edacbad2411b)|![Screenshot 2025-03-04 at 16 19 26](https://github.com/user-attachments/assets/04270fc0-29d5-446e-a00c-5d39eb591a71)|

## Other

- fixed a couple of places where we were not using native UUIDs in the responses, in particular the one on `requestDevice` was causing a bug with `watchAdvertisements` because it resulted in an upper-case UUID on the Js side so we had two instances, one in lower case and one in upper case.
- opened in issue #126 to note that on the Js side we do not implement the custom setters needed for the `on<event>` style of handlers to work with more than one instance at a time.
