### PR TITLE
Capture logs via OSLog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,5 +46,8 @@ lint-official:
 lint-fix-official:
 	swift format -i -r .
 
+log-watch:
+	log stream --source --level debug --style compact --predicate 'process=="topaz" AND sender=="topaz.debug.dylib" AND subsystem!="WebView"'
+
 clean:
 	-rm -rf .build build $(DERIVED_DATA_ROOT) $(ARTIFACTS_ROOT)

--- a/lib/Javascript/src/Bluetooth.ts
+++ b/lib/Javascript/src/Bluetooth.ts
@@ -1,5 +1,5 @@
 import { BluetoothDevice } from "./BluetoothDevice";
-import { bluetoothRequest } from "./WebKit";
+import { appLog, bluetoothRequest } from "./WebKit";
 import { ValueEvent } from "./ValueEvent";
 import { store } from "./Store";
 import { BluetoothLEScan, BluetoothLEScanOptions, doRequestLEScan } from "./BluetoothLEScan";

--- a/lib/Javascript/src/BluetoothPolyfill.ts
+++ b/lib/Javascript/src/BluetoothPolyfill.ts
@@ -2,10 +2,12 @@
 
 import { Topaz } from "./Topaz";
 import { BluetoothUUID } from "./BluetoothUUID";
+import { setupLogging } from "./Logging";
 
 if (typeof((navigator as any).bluetooth) === 'undefined') {
     globalThis.topaz = new Topaz();
     (navigator as any).bluetooth = globalThis.topaz.bluetooth;
+    setupLogging();
 }
 
 if (typeof((window as any).BluetoothUUID) === 'undefined') {

--- a/lib/Javascript/src/Logging.ts
+++ b/lib/Javascript/src/Logging.ts
@@ -1,0 +1,68 @@
+import { appLog } from "./WebKit"
+
+const safeStringify = (obj: any): string => {
+    try {
+        return JSON.stringify(obj)
+    }
+    catch (e) {
+        return `Cannot stringify object ${e.message}`
+    }
+}
+
+const logOverride = (level: string, args: IArguments) => {
+    if (args.length === 0) {
+        return;
+    }
+    let strings = [];
+    for (let i = 0; i < args.length; i++) {
+        const arg = args[i];
+        if (typeof(arg) === 'undefined') {
+            strings.push('undefined');
+        } else if (typeof(arg) === 'object') {
+            strings.push(safeStringify(arg).substring(0, 2048));
+        } else {
+            strings.push(arg.toString().substring(0, 2048));
+        }
+    }
+    appLog({
+        level: level,
+        msg: strings.join(' '),
+        console: true,
+        sensitive: false,
+    });
+}
+
+export const setupLogging = () => {
+    let originalLog = globalThis.console.log
+    let originalWarn = globalThis.console.warn
+    let originalError = globalThis.console.error
+    let originalDebug = globalThis.console.debug
+
+    globalThis.console.log = function() {
+        originalLog.apply(null, arguments);
+        logOverride('debug', arguments);
+    }
+
+    globalThis.console.warn = function() {
+        originalWarn.apply(null, arguments);
+        logOverride('warn', arguments);
+    }
+
+    globalThis.console.error = function() {
+        originalError.apply(null, arguments);
+        logOverride('error', arguments);
+    }
+
+    globalThis.console.debug = function() {
+        originalDebug.apply(null, arguments);
+        logOverride('debug', arguments);
+    }
+
+    window.addEventListener('error', (e) => {
+        appLog({
+            level: 'error',
+            msg: `Uncaught ${e}`,
+            sensitive: false,
+        });
+    });
+}

--- a/lib/Javascript/src/Topaz.ts
+++ b/lib/Javascript/src/Topaz.ts
@@ -1,5 +1,6 @@
 import { Bluetooth } from "./Bluetooth";
 import { processEvent, TargetedEvent } from "./EventSink";
+import { appLog, LogMessage } from "./WebKit";
 
 export class Topaz {
     bluetooth: Bluetooth;

--- a/lib/Javascript/src/WebKit.ts
+++ b/lib/Javascript/src/WebKit.ts
@@ -31,13 +31,14 @@ export const bluetoothRequest = function <Request, Response>(
 
 // Logging Channel
 
-type LogMessage = {
-    // TODO: log level
+export type LogMessage = {
+    level?: string;
     msg: string;
+    console?: boolean;
+    sensitive?: boolean;
+    data?: any;
 }
 
-export const appLog = function (msg: string): Promise<void> {
-    return window.webkit.messageHandlers.logging.postMessage<void>({
-        msg: msg
-    }).catch(rethrowAsDOMException);
+export const appLog = function (msg: LogMessage): Promise<void> {
+    return window.webkit.messageHandlers.logging.postMessage<void>(msg).catch(rethrowAsDOMException);
 }

--- a/lib/Sources/App/AppModel.swift
+++ b/lib/Sources/App/AppModel.swift
@@ -6,11 +6,14 @@ import DevicePicker
 import Helpers
 import JsMessage
 import Observation
+import OSLog
 import Settings
 import SwiftUI
 import Tabs
 import WebKit
 import WebView
+
+private let log = Logger(subsystem: "App", category: "AppModel")
 
 @MainActor
 @Observable
@@ -155,7 +158,7 @@ public class AppModel {
             return buildWebContainerModel(tab: tab, url: url, navBarModel: navBarModel, config: config)
         } catch {
             // TODO: navigate away due to failure and try again
-            print("Unable to load \(error)")
+            log.error("Unable to load \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }

--- a/lib/Sources/BluetoothMessage/Message.swift
+++ b/lib/Sources/BluetoothMessage/Message.swift
@@ -37,6 +37,10 @@ public struct Message {
     public let action: Action
     private let requestBody: [String: JsType]
 
+    public var rawRequestData: [String: JsType]? {
+        requestBody["data"]?.dictionary
+    }
+
     public init(action: Action, requestBody: [String: JsType] = [:]) {
         self.action = action
         self.requestBody = requestBody
@@ -48,8 +52,7 @@ public struct Message {
     }
 
     public func decode<T: JsMessageDecodable>(_ type: T.Type) -> Result<T, Error> {
-        let data = requestBody["data"]?.dictionary
-        guard let decoded = T.decode(from: data) else {
+        guard let decoded = T.decode(from: rawRequestData) else {
             return .failure(MessageDecodeError.bodyDecodeFailed("\(T.self)"))
         }
         return .success(decoded)

--- a/lib/Sources/Design/Dogpatch.swift
+++ b/lib/Sources/Design/Dogpatch.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import OSLog
 
 public enum Dogpatch: String, CaseIterable {
     case sansLight = "DogpatchSans-Light"
@@ -86,8 +87,7 @@ extension UIFont {
         let dogpatch = Dogpatch.with(weight: weight, design: design)
         let size = dogpatch.scaleMapping(for: style)
         guard let font = UIFont(name: dogpatch.rawValue, size: size) else {
-            // TODO: log this fault for developers somewhere
-            print("ERROR: font \(dogpatch.rawValue) not found")
+            fontLogger.error("Font not found: \(dogpatch.rawValue, privacy: .public)")
             return UIFont.preferredFont(forTextStyle: style.toUIFontTextStyle())
         }
         return font

--- a/lib/Sources/Design/FontRegistry.swift
+++ b/lib/Sources/Design/FontRegistry.swift
@@ -1,5 +1,8 @@
 import CoreText
 import Foundation
+import OSLog
+
+let fontLogger = Logger(subsystem: "Design", category: "FontRegistry")
 
 /// Invoke this from main app launch to load the fonts from the SPM bundle
 public func registerFonts() {
@@ -15,7 +18,6 @@ private func registerFont(bundle: Bundle, name: String, ext: String) {
     var error: Unmanaged<CFError>?
     if !CTFontManagerRegisterFontsForURL(url as CFURL, .none, &error) {
         let message = error?.takeRetainedValue().localizedDescription ?? "no error"
-        // TODO: log this fault for developers somewhere
-        print("Register font \(name) failed: \(message)")
+        fontLogger.error("Register font \(name, privacy: .public) failed: \(message, privacy: .public)")
     }
 }

--- a/lib/Sources/Helpers/NSNumber.swift
+++ b/lib/Sources/Helpers/NSNumber.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension NSNumber {
+    public func asDebugString() -> String {
+        isBoolean ? "\(boolValue)" : stringValue
+    }
+
+    public var isBoolean: Bool {
+        CFGetTypeID(self) == CFBooleanGetTypeID()
+    }
+
+    public func asHexString() -> String {
+        String(format: "0x%02llx", uint64Value)
+    }
+}

--- a/lib/Sources/JsMessage/DomError.swift
+++ b/lib/Sources/JsMessage/DomError.swift
@@ -1,4 +1,7 @@
 import Foundation
+import OSLog
+
+private let log = Logger(subsystem: "JsMessage", category: "DomError")
 
 /// Structured data representing a DOMException
 public struct DomError: Sendable, Encodable, Error {
@@ -27,8 +30,8 @@ extension DomError: JsErrorStringRepresentable {
         } catch {
             // We got an error on our error! Presumably the error text contained something crazy
             // Return a hand-rolled JSON struct and deliberately exclude the offending non-codeable text
-            // TODO: log this somewhere
             // TODO: It may be useful to display an alert on the web page for this case as well
+            log.error("DOM error encoding fault for \(Self.self, privacy: .public) caused by \(name.rawValue, privacy: .public)")
             return """
                 {
                     "name": "\(DomErrorName.encoding.rawValue)",
@@ -46,7 +49,7 @@ public protocol DomErrorConvertable {
 extension Error {
     public func toDomError() -> DomError {
         guard let name = (self as? DomErrorConvertable)?.domErrorName else {
-            // TODO: log this case where we probably forgot to add conformance to one of the error types
+            log.warning("DOM error conformance missing for \(Self.self, privacy: .public): \(self.localizedDescription, privacy: .public)")
             return DomError(name: .unknown, message: "\(Self.self): \(self.localizedDescription)")
         }
         return DomError(name: name, message: self.localizedDescription)

--- a/lib/Sources/JsMessage/JsConvertable+Debug.swift
+++ b/lib/Sources/JsMessage/JsConvertable+Debug.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Helpers
+
+extension JsConvertable {
+    public func asDebugString() -> String {
+        debugString(from: jsValue)
+    }
+
+    private func debugString(from jsValue: Any) -> String {
+        switch jsValue {
+        case let value as NSNumber:
+            value.asDebugString()
+        case let value as NSString:
+            value as String
+        case let value as NSDate:
+            DateFormatter.localizedString(from: value as Date, dateStyle: .short, timeStyle: .short)
+        case let value as NSArray:
+            arrayAsString(value)
+        case let value as NSDictionary:
+            dictionaryAsString(value)
+        case is NSNull:
+            "null"
+        default:
+            "<\(type(of: self.jsValue))>"
+        }
+    }
+
+    private func dictionaryAsString(_ data: NSDictionary) -> String {
+        let strings = data.map { (key, jsValue) in
+            "\(key):\(debugString(from: jsValue))"
+        }
+        return strings.isEmpty ? "" : "{ \(strings.joined(separator: ", ")) }"
+    }
+
+    private func arrayAsString(_ items: NSArray) -> String {
+        let strings = items.map(debugString)
+        return strings.isEmpty ? "" : "[ \(strings.joined(separator: ", ")) ]"
+    }
+}

--- a/lib/Sources/JsMessage/JsLogger.swift
+++ b/lib/Sources/JsMessage/JsLogger.swift
@@ -1,5 +1,13 @@
+import OSLog
+
+private let log = Logger(subsystem: "JsMessage", category: "JsLogger")
+private let consoleLog = Logger(subsystem: "JsMessage", category: "JsConsole")
 
 public final class JsLogger: JsMessageProcessor {
+    enum Level {
+        case debug, info, warn, error
+    }
+
     public static let handlerName = "logging"
     public let enableDebugLogging = false
 
@@ -17,8 +25,82 @@ public final class JsLogger: JsMessageProcessor {
         guard let message = request.body["msg"]?.string else {
             return .error(DomError(name: .encoding, message: "Log body missing required field 'msg'"))
         }
-        // For now just use the console for debug logging
-        print("JsLog: \(message)")
+        let level = decodeLevel(request.body["level"]?.string)
+        let sensitive = request.body["sensitive"]?.number?.boolValue ?? false
+        let isConsole = request.body["console"]?.number?.boolValue ?? false
+        let data = request.body["data"]?.dictionary ?? [:]
+        sendLog(level: level, isConsole: isConsole, sensitive: sensitive, message: message, data: data)
         return .body([:])
+    }
+
+    private func sendLog(level: Level, isConsole: Bool, sensitive: Bool, message: String, data: [String: JsType]?) {
+        if isConsole {
+            sendLogConsole(level: level, message: message, data: JsType.dictionaryAsString(data))
+        } else if sensitive {
+            sendLogRedacted(level: level, message: message, data: JsType.dictionaryAsString(data))
+        } else {
+            sendLogPublic(level: level, message: message, data: JsType.dictionaryAsString(data))
+        }
+    }
+
+    private func sendLogConsole(level: Level, message: String, data: String) {
+        switch level {
+        case .debug:
+            consoleLog.debug("\(message, privacy: .public) \(data, privacy: .public)")
+        case .info:
+            consoleLog.info("\(message, privacy: .public) \(data, privacy: .public)")
+        case .warn:
+            consoleLog.warning("\(message, privacy: .public) \(data, privacy: .public)")
+        case .error:
+            consoleLog.error("\(message, privacy: .public) \(data, privacy: .public)")
+        }
+    }
+
+    private func sendLogPublic(level: Level, message: String, data: String) {
+        switch level {
+        case .debug:
+            log.debug("\(message, privacy: .public) \(data, privacy: .public)")
+        case .info:
+            log.info("\(message, privacy: .public) \(data, privacy: .public)")
+        case .warn:
+            log.warning("\(message, privacy: .public) \(data, privacy: .public)")
+        case .error:
+            log.error("\(message, privacy: .public) \(data, privacy: .public)")
+        }
+    }
+
+    private func sendLogRedacted(level: Level, message: String, data: String) {
+        switch level {
+        case .debug:
+            log.debug("\(message, privacy: .public) \(data, privacy: .private)")
+        case .info:
+            log.info("\(message, privacy: .public) \(data, privacy: .private)")
+        case .warn:
+            log.warning("\(message, privacy: .public) \(data, privacy: .private)")
+        case .error:
+            log.error("\(message, privacy: .public) \(data, privacy: .private)")
+        }
+    }
+
+    private func decodeLevel(_ string: String?) -> Level {
+        guard let string else {
+            return .debug
+        }
+        return switch string {
+        case "info": .info
+        case "warn": .warn
+        case "error": .error
+        default: .debug
+        }
+    }
+
+    private func decodePrivacy(_ string: String?) -> OSLogPrivacy {
+        guard let string else {
+            return .public
+        }
+        return switch string {
+        case "private": .private
+        default: .public
+        }
     }
 }

--- a/lib/Sources/JsMessage/JsType+Debug.swift
+++ b/lib/Sources/JsMessage/JsType+Debug.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Helpers
+
+extension JsType {
+    public func asDebugString() -> String {
+        switch self {
+        case let .number(number): number.asDebugString()
+        case let .string(string): string
+        case let .date(date): DateFormatter.localizedString(from: date, dateStyle: .short, timeStyle: .short)
+        case let .array(items): arrayAsString(items)
+        case let .dictionary(data): Self.dictionaryAsString(data)
+        case .null: "null"
+        }
+    }
+
+    public static func dictionaryAsString(_ data: [String: JsType]?) -> String {
+        guard let data else { return "" }
+        let strings = data.map { (key, value) in
+            "\(key):\(value.asDebugString())"
+        }
+        return strings.isEmpty ? "" : "{ \(strings.joined(separator: ", ")) }"
+    }
+
+    private func arrayAsString(_ items: [JsType]) -> String {
+        let strings = items.map { $0.asDebugString() }
+        return strings.isEmpty ? "" : "[ \(strings.joined(separator: ", ")) ]"
+    }
+}

--- a/lib/Sources/WebView/Coordinator.swift
+++ b/lib/Sources/WebView/Coordinator.swift
@@ -96,9 +96,6 @@ public class Coordinator: NSObject {
 extension WKWebView {
     func createContext(contextId: JsContextIdentifier, world: WKContentWorld) -> JsContext {
         return JsContext(id: contextId) { [weak self] event in
-#if DEBUG
-            print("EVENT: \(event.jsValue)")
-#endif
             return await withCheckedContinuation { continuation in
                 self?.callAsyncJavaScript(
                     "topaz.sendEvent(event)",

--- a/lib/Sources/WebView/Resources/Generated/BluetoothPolyfill.js
+++ b/lib/Sources/WebView/Resources/Generated/BluetoothPolyfill.js
@@ -17,6 +17,9 @@ const bluetoothRequest = function (action, data) {
         data: data
     }).catch(rethrowAsDOMException);
 };
+const appLog = function (msg) {
+    return window.webkit.messageHandlers.logging.postMessage(msg).catch(rethrowAsDOMException);
+};
 
 const uint8ArrayToBase64 = (uint8array) => {
     return btoa(String.fromCharCode(...uint8array));
@@ -804,9 +807,72 @@ class Topaz {
     }
 }
 
+const safeStringify = (obj) => {
+    try {
+        return JSON.stringify(obj);
+    }
+    catch (e) {
+        return `Cannot stringify object ${e.message}`;
+    }
+};
+const logOverride = (level, args) => {
+    if (args.length === 0) {
+        return;
+    }
+    let strings = [];
+    for (let i = 0; i < args.length; i++) {
+        const arg = args[i];
+        if (typeof (arg) === 'undefined') {
+            strings.push('undefined');
+        }
+        else if (typeof (arg) === 'object') {
+            strings.push(safeStringify(arg).substring(0, 2048));
+        }
+        else {
+            strings.push(arg.toString().substring(0, 2048));
+        }
+    }
+    appLog({
+        level: level,
+        msg: strings.join(' '),
+        console: true,
+        sensitive: false,
+    });
+};
+const setupLogging = () => {
+    let originalLog = globalThis.console.log;
+    let originalWarn = globalThis.console.warn;
+    let originalError = globalThis.console.error;
+    let originalDebug = globalThis.console.debug;
+    globalThis.console.log = function () {
+        originalLog.apply(null, arguments);
+        logOverride('debug', arguments);
+    };
+    globalThis.console.warn = function () {
+        originalWarn.apply(null, arguments);
+        logOverride('warn', arguments);
+    };
+    globalThis.console.error = function () {
+        originalError.apply(null, arguments);
+        logOverride('error', arguments);
+    };
+    globalThis.console.debug = function () {
+        originalDebug.apply(null, arguments);
+        logOverride('debug', arguments);
+    };
+    window.addEventListener('error', (e) => {
+        appLog({
+            level: 'error',
+            msg: `Uncaught ${e}`,
+            sensitive: false,
+        });
+    });
+};
+
 if (typeof (navigator.bluetooth) === 'undefined') {
     globalThis.topaz = new Topaz();
     navigator.bluetooth = globalThis.topaz.bluetooth;
+    setupLogging();
 }
 if (typeof (window.BluetoothUUID) === 'undefined') {
     globalThis.BluetoothUUID = BluetoothUUID;

--- a/lib/Sources/WebView/ScriptHandler.swift
+++ b/lib/Sources/WebView/ScriptHandler.swift
@@ -51,22 +51,7 @@ extension ScriptHandler: WKScriptMessageHandlerWithReply {
         guard let processor = await getProcessor(named: request.handlerName) else {
             return (nil, "Handler not found for \(request.handlerName)")
         }
-#if DEBUG
-        if processor.enableDebugLogging {
-            print("REQUEST \(message.name): \(message.body)")
-        }
-#endif
         let result = await processor.process(request: request, in: context)
-#if DEBUG
-        switch result {
-        case let .body(value):
-            if processor.enableDebugLogging {
-                print("RESPONSE \(message.name): \(value.jsValue)")
-            }
-        case let .error(reason):
-            print("RESPONSE \(message.name) ERROR: \(reason)")
-        }
-#endif
         return switch result {
         case let .body(value):
             (value.jsValue, nil)

--- a/lib/Sources/WebView/WebPageView.swift
+++ b/lib/Sources/WebView/WebPageView.swift
@@ -33,6 +33,9 @@ public struct WebPageView: View {
 
         func makeUIView(context: Context) -> WKWebView {
             let webView = model.createWebView()
+#if DEBUG
+            webView.isInspectable = true
+#endif
             context.coordinator.initialize(webView: webView, model: model)
             Task { @MainActor in
                 scrollView = webView.scrollView


### PR DESCRIPTION
## Changes

- capture console log messages from Javascript and push them up to the `JsLogger`
- fill out `JsLogger` to use OSLog and separate app logs from general console logs
- refactor the script handler logging to use OSLog
- find any old print messages and have them use OSLog

_Note: I'm filtering where subsystem!=WebView in the below examples to exclude the noise from the navigator delegate logging_

## Xcode console when attached to iPhone

|Console|
|---|
|<img width="1300" alt="Screenshot 2025-03-05 at 17 38 46" src="https://github.com/user-attachments/assets/56a1b995-cd4e-4051-b826-c8cfca5da14b" />|

## MacOS log tool when running iPad variant

```
$ make run
$ make log-watch
log stream --source --level debug --style compact --predicate 'process=="topaz" AND sender=="topaz.debug.dylib" AND subsystem!="WebView"'
Filtering the log data using "process == "topaz" AND sender == "topaz.debug.dylib" AND subsystem != "WebView""
Timestamp               Ty Process[PID:TID]
2025-03-05 17:56:59.781 Db topaz[36177:31d2f41] [BluetoothEngine:Message] <topaz.debug.dylib`BluetoothEngine.logRequest(message:) (BluetoothEngine.swift:171)> Request requestDevice: { options:{ optionalServices:, acceptAllDevices:true } }
2025-03-05 17:57:29.720 Db topaz[36177:31d3867] [BluetoothEngine:Message] <topaz.debug.dylib`BluetoothEngine.logResponse(action:response:) (BluetoothEngine.swift:178)> Response requestDevice: { uuid:C8E067DA-D127-5C15-59E3-F774CCFBBC2C, name:NUEAJ }
2025-03-05 17:57:29.741 Db topaz[36177:31d33d8] [BluetoothEngine:Message] <topaz.debug.dylib`BluetoothEngine.logRequest(message:) (BluetoothEngine.swift:171)> Request connect: { uuid:C8E067DA-D127-5C15-59E3-F774CCFBBC2C }
2025-03-05 17:57:30.426 Db topaz[36177:31d2f41] [BluetoothEngine:Message] <topaz.debug.dylib`BluetoothEngine.logResponse(action:response:) (BluetoothEngine.swift:178)> Response connect: { connected:true }
2025-03-05 17:57:30.430 Db topaz[36177:31d33d8] [BluetoothEngine:Message] <topaz.debug.dylib`BluetoothEngine.logRequest(message:) (BluetoothEngine.swift:171)> Request discoverServices: { service:null, device:C8E067DA-D127-5C15-59E3-F774CCFBBC2C, single:false }
2025-03-05 17:57:30.754 Db topaz[36177:31d33d8] [BluetoothEngine:Message] <topaz.debug.dylib`BluetoothEngine.logResponse(action:response:) (BluetoothEngine.swift:178)> Response discoverServices: { services:[ 0000feaf-0000-1000-8000-00805f9b34fb ] }
2025-03-05 17:57:30.757 Db topaz[36177:31d3867] [BluetoothEngine:Message] <topaz.debug.dylib`BluetoothEngine.logRequest(message:) (BluetoothEngine.swift:171)> Request discoverCharacteristics: { service:0000feaf-0000-1000-8000-00805f9b34fb, single:false, device:C8E067DA-D127-5C15-59E3-F774CCFBBC2C, characteristic:null }
2025-03-05 17:57:30.936 Db topaz[36177:31d33d8] [BluetoothEngine:Message] <topaz.debug.dylib`BluetoothEngine.logResponse(action:response:) (BluetoothEngine.swift:178)> Response discoverCharacteristics: { characteristics:[ { uuid:18ee2ef5-263d-4559-959f-4f9c429f9d11, properties:{ write:true, notify:false, indicate:false, authenticatedSignedWrites:false, reliableWrite:false, writeWithoutResponse:false, read:true, writableAuxiliaries:false, broadcast:false }, instance:2697668563 }, { properties:{ reliableWrite:false, write:false, authenticatedSignedWrites:false, indicate:true, writableAuxiliaries:false, writeWithoutResponse:false, read:true, broadcast:false, notify:false }, uuid:18ee2ef5-263d-4559-959f-4f9c429f9d12, instance:1273418247 } ] }
```

## Capture Js console.log

|Web page|Console|
|---|---|
|![phone_console_log_test](https://github.com/user-attachments/assets/4ea5c91c-f9bd-4827-8ad8-3f0111b6425c)|![xcode_console_log_test](https://github.com/user-attachments/assets/54967815-2e94-4621-9916-eb5a7951fc01)|
