### PR TITLE
Deterministic characteristic instance IDs

### DIFF
--- a/lib/Sources/BluetoothNative/CBCharacteristic.swift
+++ b/lib/Sources/BluetoothNative/CBCharacteristic.swift
@@ -4,8 +4,13 @@ import Foundation
 import Helpers
 
 extension CBCharacteristic {
+    final class InstanceStorage: AssociatedObject {
+        var instance: UInt32 = 0
+    }
+
     var instanceId: UInt32 {
-        UInt32(truncatingIfNeeded: ObjectIdentifier(self).hashValue)
+        get { get(InstanceStorage.self).instance }
+        set { get(InstanceStorage.self).instance = newValue }
     }
 }
 

--- a/lib/Sources/Helpers/AssociatedObject.swift
+++ b/lib/Sources/Helpers/AssociatedObject.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/**
+ Swift wrapper for leveraging objc_get/setAssociatedObject to add properties in extensions.
+
+ Example use:
+ ```
+ extension SomeObject {
+    final class ExtraStorage: AssociatedObject {
+        var someValue: Int = 0
+    }
+
+    var someValue: Int {
+        get { get(ExtraStorage.self).someValue }
+        set { get(ExtraStorage.self).someValue = newValue }
+    }
+ }
+ ```
+ */
+public protocol AssociatedObject: AnyObject {
+    static var key: UnsafeRawPointer { get }
+    init()
+}
+
+public extension AssociatedObject {
+    static var key: UnsafeRawPointer { UnsafeRawPointer(bitPattern: UInt(bitPattern: ObjectIdentifier(Self.self)))! }
+}
+
+public extension NSObject {
+    func get<Object: AssociatedObject>(_ objectClass: Object.Type ) -> Object {
+        var object = objc_getAssociatedObject(self, Object.key) as? Object
+        if object == nil {
+            object = objectClass.init()
+            objc_setAssociatedObject(self, Object.key, object, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+        return object!
+    }
+}


### PR DESCRIPTION
We have been using `ObjectIdentifier` on the characteristic object to create an instance identifier. Unfortunately this is not stable in the case where a client invokes `discoverCharacteristics` more than once. Each time the delegate callback is invoked it provides new instances of `CBCharacteristic` objects on the service. This leads to a proliferation of duplicate characteristics in both the local state and in the Js object graph. Then requests that use the older instances will fail.

The fix here is to generate a stable enumerated instance identifier based on the order of objects returned on the discovery callback. We have no guarantee but can only assume that these will always be in the same order if a device returns duplicates.

