### PR TITLE
Propagate unexpected disconnection events

### DIFF
--- a/lib/Sources/BluetoothAction/Disconnect.swift
+++ b/lib/Sources/BluetoothAction/Disconnect.swift
@@ -38,8 +38,19 @@ struct Disconnector: BluetoothAction {
     }
 }
 
-extension PeripheralEvent {
+extension DisconnectionEvent {
     public func gattServerDisconnectedEvent() -> JsEvent {
-        JsEvent(targetId: peripheral.id.uuidString.lowercased(), eventName: "gattserverdisconnected")
+        let (peripheralId, reason) =
+        switch self {
+        case let .requested(peripheral):
+            (peripheral.id, "disconnected")
+        case let .unexpected(peripheral, cause):
+            (peripheral.id, cause.localizedDescription)
+        }
+        return JsEvent(
+            targetId: peripheralId.uuidString.lowercased(),
+            eventName: "gattserverdisconnected",
+            body: ["reason": reason]
+        )
     }
 }

--- a/lib/Sources/BluetoothAction/JsEvent.swift
+++ b/lib/Sources/BluetoothAction/JsEvent.swift
@@ -8,8 +8,7 @@ extension BluetoothEvent {
         switch self {
         case let event as SystemStateEvent:
             event.availabilityChangedEvent()
-        case let event as PeripheralEvent where event.name == .disconnect:
-            // TODO: can we forward the error case here somehow?
+        case let event as DisconnectionEvent:
             event.gattServerDisconnectedEvent()
         case let event as CharacteristicChangedEvent:
             event.characteristicValueChangedEvent()

--- a/lib/Sources/BluetoothClient/Events/DisconnectionEvent.swift
+++ b/lib/Sources/BluetoothClient/Events/DisconnectionEvent.swift
@@ -1,0 +1,17 @@
+import Bluetooth
+
+public enum DisconnectionEvent: BluetoothEvent {
+    case requested(Peripheral)
+    case unexpected(Peripheral, any Error)
+
+    public var peripheral: Peripheral {
+        switch self {
+        case let .requested(peripheral): peripheral
+        case let .unexpected(peripheral, _): peripheral
+        }
+    }
+
+    public var lookup: EventLookup {
+        .exact(key: .peripheral(.disconnect, peripheral))
+    }
+}

--- a/lib/Sources/BluetoothEngine/BluetoothEngine.swift
+++ b/lib/Sources/BluetoothEngine/BluetoothEngine.swift
@@ -44,6 +44,19 @@ public actor BluetoothEngine: JsMessageProcessor {
         await updateState(for: event)
         await sendJsEvent(for: event)
         await client.resolvePendingRequests(for: event)
+        await handleUnexpectedDisconnect(for: event)
+    }
+
+    // On unexpected disconnect reject all pending operations for the peripheral
+    private func handleUnexpectedDisconnect(for event: BluetoothEvent) async {
+        guard case let DisconnectionEvent.unexpected(peripheral, cause) = event else {
+            return
+        }
+        let disconnectionErrorEvent = ErrorEvent(
+            error: cause,
+            lookup: .wildcard(peripheralId: peripheral.id)
+        )
+        await client.resolvePendingRequests(for: disconnectionErrorEvent)
     }
 
     private func updateState(for event: BluetoothEvent) async {

--- a/lib/Sources/BluetoothNative/RelayDelegate.swift
+++ b/lib/Sources/BluetoothNative/RelayDelegate.swift
@@ -30,7 +30,12 @@ class EventDelegate: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate {
 
     func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: (any Error)?) {
         peripheral.delegate = nil
-        handlePeripheralEvent(.disconnect, peripheral: peripheral, error: error)
+        let event = if let error {
+            DisconnectionEvent.unexpected(peripheral.erase(locker: locker), error)
+        } else {
+            DisconnectionEvent.requested(peripheral.erase(locker: locker))
+        }
+        handleEvent(event)
     }
 
     // MARK: - CBPeripheralDelegate


### PR DESCRIPTION
## Problem

When a device disconnects unexpectedly (e.g. goes out of range) we were failing to propagate the `gattserverdisconnected` event to Javascript.

These events are emitted by the delegate and can be distinguished from expected disconnections by the fact that there is an accompanying `Error`. We emit `EventName.disconnected` normally, and `ErrorEvent` on error from the delegate callback.

The issue is that we we only send `gattserverdisconnected` for `EventName.disconnected` events and not for `ErrorEvent` events, so unexpected disconnections end up on the floor.

## Fix

Added `DisconnectionEvent` to model both expected or unexpected disconnects. Both of these will propagate as `gattserverdisconnected` to the Js side.

For expected disconnects (i.e. explicitly requested) this event will resolve any pending disconnect requests.

For unexpected disconnects we must also further reject all pending operations for the peripheral.
