### PR TITLE
Perform percent string interpolation on Js logs

### DIFF
--- a/lib/Javascript/src/Logging.ts
+++ b/lib/Javascript/src/Logging.ts
@@ -9,10 +9,35 @@ const safeStringify = (obj: any): string => {
     }
 }
 
+const percentInterpolation = (format: string, args: any[]): string => {
+    if (typeof(format) !== 'string') {
+        return;
+    }
+    if (args.length === 0) {
+        return format;
+    }
+    if (!/%s|%v|%d|%f/.test(format)) {
+        return;
+    }
+    return args.reduce((str, val) => str.replace(/%s|%v|%d|%f/, val), format);
+}
+
 const logOverride = (level: string, args: IArguments) => {
     if (args.length === 0) {
         return;
     }
+
+    let formatted = percentInterpolation(args[0], Array.prototype.slice.call(args, 1));
+    if (formatted) {
+        appLog({
+            level: level,
+            msg: formatted.substring(0, 2048),
+            console: true,
+            sensitive: false,
+        });
+        return;
+    }
+
     let strings = [];
     for (let i = 0; i < args.length; i++) {
         const arg = args[i];
@@ -20,6 +45,8 @@ const logOverride = (level: string, args: IArguments) => {
             strings.push('undefined');
         } else if (typeof(arg) === 'object') {
             strings.push(safeStringify(arg).substring(0, 2048));
+        } else if (typeof(arg) === 'string') {
+            strings.push(arg.substring(0, 2048));
         } else {
             strings.push(arg.toString().substring(0, 2048));
         }

--- a/lib/Sources/WebView/Resources/Generated/BluetoothPolyfill.js
+++ b/lib/Sources/WebView/Resources/Generated/BluetoothPolyfill.js
@@ -850,8 +850,30 @@ const safeStringify = (obj) => {
         return `Cannot stringify object ${e.message}`;
     }
 };
+const percentInterpolation = (format, args) => {
+    if (typeof (format) !== 'string') {
+        return;
+    }
+    if (args.length === 0) {
+        return format;
+    }
+    if (!/%s|%v|%d|%f/.test(format)) {
+        return;
+    }
+    return args.reduce((str, val) => str.replace(/%s|%v|%d|%f/, val), format);
+};
 const logOverride = (level, args) => {
     if (args.length === 0) {
+        return;
+    }
+    let formatted = percentInterpolation(args[0], Array.prototype.slice.call(args, 1));
+    if (formatted) {
+        appLog({
+            level: level,
+            msg: formatted.substring(0, 2048),
+            console: true,
+            sensitive: false,
+        });
         return;
     }
     let strings = [];
@@ -862,6 +884,9 @@ const logOverride = (level, args) => {
         }
         else if (typeof (arg) === 'object') {
             strings.push(safeStringify(arg).substring(0, 2048));
+        }
+        else if (typeof (arg) === 'string') {
+            strings.push(arg.substring(0, 2048));
         }
         else {
             strings.push(arg.toString().substring(0, 2048));


### PR DESCRIPTION
As of #128 we concatenate all arguments to `console.log` and forward to the OSLog system. However some Js frameworks use a percent encoding interpreter for the log arguments so we end up with the format string followed by the arguments which is confusing to read.

This change does a simple check and naive interpretation of base percent placeholders to provide a more readable log output.

In the below example, the callsite is doing something like this:
```javascript
  console.log('[%s] %s', 'IndexedDB/Transaction', 'Opened readonly transaction 0 using stores `application` on database `preferences`');
```

Here is a short diff of some log output from before and after the change:

```diff
1,2c1,2
< [%s] %s IndexedDB/Transaction Opened readonly transaction 0 using stores `application` on database `preferences`
< [%s] %s IndexedDB/Transaction Closed readonly transaction 0 on database `preferences`
---
> [IndexedDB/Transaction] Opened readonly transaction 0 using stores `application` on database `preferences`
> [IndexedDB/Transaction] Closed readonly transaction 0 on database `preferences`
4,5c4,5
< [%s] %s IndexedDB/Transaction Opened readonly transaction 1 using stores `user` on database `preferences`
< [%s] %s IndexedDB/Transaction Closed readonly transaction 1 on database `preferences`
---
> [IndexedDB/Transaction] Opened readonly transaction 1 using stores `user` on database `preferences`
> [IndexedDB/Transaction] Closed readonly transaction 1 on database `preferences`
```
