### PR TITLE
Fix bugs with multiple peripherals

### DIFF
--- a/lib/Javascript/src/CharacteristicValueChangedEvent.ts
+++ b/lib/Javascript/src/CharacteristicValueChangedEvent.ts
@@ -1,0 +1,28 @@
+import { BluetoothRemoteGATTCharacteristic } from "./BluetoothRemoteGATTCharacteristic";
+import { base64ToDataView } from "./Data";
+import type { TargetedEvent } from "./EventSink";
+import { store } from "./Store";
+import { ValueEvent } from "./ValueEvent";
+
+export type CharacteristicEvent = {
+    characteristic: BluetoothRemoteGATTCharacteristic;
+    event: ValueEvent<DataView>;
+}
+
+// The payload as defined in the Swift code CharacteristicResponse:
+type CharacteristicEventPayload = {
+    device: string;
+    service: string;
+    characteristic: string;
+    instance: number;
+    value: string;
+}
+
+// Assumes event.name === 'characteristicvaluechanged'
+// Side effect: updates the value property of the characteristic in the store
+export const convertToCharacteristicEvent = (event: TargetedEvent): CharacteristicEvent => {
+    const payload: CharacteristicEventPayload = event.data;
+    const data = base64ToDataView(payload.value);
+    const characteristic = store.updateCharacteristicValue(payload.device, payload.service, payload.characteristic, payload.instance, data);
+    return { characteristic, event: new ValueEvent(event.name, { value: data }) };
+}

--- a/lib/Javascript/src/CharacteristicValueChangedEvent.ts
+++ b/lib/Javascript/src/CharacteristicValueChangedEvent.ts
@@ -9,7 +9,7 @@ export type CharacteristicEvent = {
     event: ValueEvent<DataView>;
 }
 
-// The payload as defined in the Swift code CharacteristicResponse:
+// The payload as defined in the Swift code CharacteristicChangedEvent:
 type CharacteristicEventPayload = {
     device: string;
     service: string;

--- a/lib/Javascript/src/EventSink.ts
+++ b/lib/Javascript/src/EventSink.ts
@@ -1,4 +1,5 @@
 import { convertToAdvertisingEvent } from "./BluetoothAdvertisingEvent";
+import { convertToCharacteristicEvent } from "./CharacteristicValueChangedEvent";
 import { base64ToDataView } from "./Data";
 import { store } from "./Store";
 import { ValueEvent } from "./ValueEvent";
@@ -31,10 +32,9 @@ export const processEvent = (event: TargetedEvent) => {
         pushDeviceTarget();
     } else if (event.name === 'characteristicvaluechanged') {
         // Decode the data payload, update the store, and forward event to the specific characteristic
-        const data = base64ToDataView(event.data);
-        const characteristic = store.updateCharacteristicValue(event.id, data);
-        targets.push(characteristic);
-        eventToSend = new ValueEvent(event.name, { value: data });
+        const characteristicEvent = convertToCharacteristicEvent(event);
+        targets.push(characteristicEvent.characteristic);
+        eventToSend = characteristicEvent.event;
     } else if (event.name === 'advertisementreceived') {
         eventToSend = convertToAdvertisingEvent(event);
         pushDeviceTarget();

--- a/lib/Javascript/src/Logging.ts
+++ b/lib/Javascript/src/Logging.ts
@@ -9,6 +9,8 @@ const safeStringify = (obj: any): string => {
     }
 }
 
+// TODO: Some more work to do here to implement the full-spec properly:
+// https://console.spec.whatwg.org/#formatting-specifiers
 const percentInterpolation = (format: string, args: any[]): string => {
     if (typeof(format) !== 'string') {
         return;
@@ -16,10 +18,10 @@ const percentInterpolation = (format: string, args: any[]): string => {
     if (args.length === 0) {
         return format;
     }
-    if (!/%s|%v|%d|%f/.test(format)) {
+    if (!/%s|%v|%o|%d|%i|%f/.test(format)) {
         return;
     }
-    return args.reduce((str, val) => str.replace(/%s|%v|%d|%f/, val), format);
+    return args.reduce((str, val) => str.replace(/%s|%v|%o|%d|%i|%f/, val), format);
 }
 
 const logOverride = (level: string, args: IArguments) => {

--- a/lib/Javascript/src/Store.ts
+++ b/lib/Javascript/src/Store.ts
@@ -80,22 +80,10 @@ class Store {
         serviceRecord.characteristics.set(keyForCharacteristic(characteristic), { uuid: characteristic.uuid, characteristic, descriptors: new Map() });
     }
 
-    private findCharacteristic = (key: CharacteristicKey): BluetoothRemoteGATTCharacteristic | undefined => {
-        for (const deviceRecord of this.#devices.values()) {
-            for (const serviceRecord of deviceRecord.services.values()) {
-                const characteristic = serviceRecord.characteristics.get(key)?.characteristic;
-                if (characteristic) {
-                    return characteristic;
-                }
-            }
-        }
-        return undefined;
-    }
-
-    updateCharacteristicValue = (key: CharacteristicKey, value: DataView): BluetoothRemoteGATTCharacteristic => {
-        const characteristic = this.findCharacteristic(key);
+    updateCharacteristicValue = (deviceUuid: string, serviceUuid: string, uuid: string, instance: number, value: DataView): BluetoothRemoteGATTCharacteristic => {
+        const characteristic = this.#devices.get(deviceUuid)?.services.get(serviceUuid)?.characteristics.get(characteristicKey(uuid, instance))?.characteristic;
         if (!characteristic) {
-            throw new ReferenceError(`Characteristic ${key} not found`);
+            throw new ReferenceError(`Characteristic ${uuid} not found`);
         }
         characteristic.value = value;
         return characteristic;

--- a/lib/Sources/BluetoothAction/DiscoverDescriptors.swift
+++ b/lib/Sources/BluetoothAction/DiscoverDescriptors.swift
@@ -70,7 +70,7 @@ struct DiscoverDescriptors: BluetoothAction {
 
     func execute(state: BluetoothState, client: BluetoothClient) async throws -> DiscoverDescriptorsResponse {
         let peripheral = try await state.getConnectedPeripheral(request.peripheralId)
-        let characteristic = try await state.getCharacteristic(
+        let (_, characteristic) = try await state.getCharacteristic(
             peripheralId: request.peripheralId,
             serviceId: request.serviceUuid,
             characteristicId: request.characteristicUuid,

--- a/lib/Sources/BluetoothAction/ReadCharacteristic.swift
+++ b/lib/Sources/BluetoothAction/ReadCharacteristic.swift
@@ -10,20 +10,23 @@ struct ReadCharacteristic: BluetoothAction {
 
     func execute(state: BluetoothState, client: BluetoothClient) async throws -> CharacteristicResponse {
         let peripheral = try await state.getConnectedPeripheral(request.peripheralId)
-        let characteristic = try await state.getCharacteristic(peripheralId: request.peripheralId, serviceId: request.serviceUuid, characteristicId: request.characteristicUuid, instance: request.characteristicInstance)
+        let (service, characteristic) = try await state.getCharacteristic(peripheralId: request.peripheralId, serviceId: request.serviceUuid, characteristicId: request.characteristicUuid, instance: request.characteristicInstance)
         // The Js characteristic object's `value` is mutated via an event that is triggered by the read
         // So we ignore the result here and over on the Js side the updated value gets read from the characteristic directly
-        _ = try await client.characteristicRead(peripheral, characteristic: characteristic)
+        _ = try await client.characteristicRead(peripheral, service: service, characteristic: characteristic)
         return CharacteristicResponse()
     }
 }
 
 extension CharacteristicChangedEvent {
-    public func characteristicValueChangedEvent() -> JsEvent {
-        JsEvent(targetId: characteristicKey(uuid: characteristicId, instance: instance), eventName: "characteristicvaluechanged", body: data)
+    func characteristicValueChangedEvent() -> JsEvent {
+        let body: [String: JsConvertable] = [
+            "device": peripheralId,
+            "service": serviceId,
+            "characteristic": characteristicId,
+            "instance": instance,
+            "value": data ?? jsNull,
+        ]
+        return JsEvent(targetId: characteristicId.uuidString.lowercased(), eventName: "characteristicvaluechanged", body: body)
     }
-}
-
-private func characteristicKey(uuid: UUID, instance: UInt32) -> String {
-    "\(uuid.uuidString.lowercased()).\(instance)"
 }

--- a/lib/Sources/BluetoothAction/ReadDescriptor.swift
+++ b/lib/Sources/BluetoothAction/ReadDescriptor.swift
@@ -45,7 +45,7 @@ struct ReadDescriptor: BluetoothAction {
 
     func execute(state: BluetoothState, client: BluetoothClient) async throws -> ReadDescriptorResponse {
         let peripheral = try await state.getConnectedPeripheral(request.peripheralId)
-        let characteristic = try await state.getCharacteristic(
+        let (_, characteristic) = try await state.getCharacteristic(
             peripheralId: request.peripheralId,
             serviceId: request.serviceUuid,
             characteristicId: request.characteristicUuid,

--- a/lib/Sources/BluetoothAction/RequestDevice.swift
+++ b/lib/Sources/BluetoothAction/RequestDevice.swift
@@ -59,7 +59,7 @@ struct RequestDevice: BluetoothAction {
         }
         let peripheral = try await selector.awaitSelection().get()
         task.cancel()
-        await state.putPeripheral(peripheral)
+        await state.putPeripheral(peripheral, replace: true)
         return RequestDeviceResponse(peripheralId: peripheral.id, name: peripheral.name)
     }
 }

--- a/lib/Sources/BluetoothAction/RequestLEScan.swift
+++ b/lib/Sources/BluetoothAction/RequestLEScan.swift
@@ -104,7 +104,7 @@ struct RequestLEScan: BluetoothAction {
             for await event in scanner.advertisements {
                 guard !Task.isCancelled else { return }
                 // TODO: Potential optimization: keep track of these devices and discard them if never connected after scanning
-                await state.putPeripheral(event.peripheral)
+                await state.putPeripheral(event.peripheral, replace: false)
                 await jsEventForwarder.forwardEvent(event.toJs(targetId: "bluetooth"))
             }
         }

--- a/lib/Sources/BluetoothAction/StartNotifications.swift
+++ b/lib/Sources/BluetoothAction/StartNotifications.swift
@@ -14,7 +14,7 @@ struct StartNotifications: BluetoothAction {
 
     func execute(state: BluetoothState, client: any BluetoothClient) async throws -> CharacteristicResponse {
         let peripheral = try await state.getConnectedPeripheral(request.peripheralId)
-        let characteristic = try await state.getCharacteristic(peripheralId: request.peripheralId, serviceId: request.serviceUuid, characteristicId: request.characteristicUuid, instance: request.characteristicInstance)
+        let (service, characteristic) = try await state.getCharacteristic(peripheralId: request.peripheralId, serviceId: request.serviceUuid, characteristicId: request.characteristicUuid, instance: request.characteristicInstance)
 
         guard characteristic.properties.contains(.notify) || characteristic.properties.contains(.indicate) else {
             throw BluetoothError.characteristicNotificationsNotSupported(characteristic: request.characteristicUuid)
@@ -23,7 +23,7 @@ struct StartNotifications: BluetoothAction {
             return CharacteristicResponse()
         }
 
-        _ = try await client.characteristicSetNotifications(peripheral, characteristic: characteristic, enable: true)
+        _ = try await client.characteristicSetNotifications(peripheral, service: service, characteristic: characteristic, enable: true)
 
         return CharacteristicResponse()
     }

--- a/lib/Sources/BluetoothAction/StopNotifications.swift
+++ b/lib/Sources/BluetoothAction/StopNotifications.swift
@@ -14,8 +14,8 @@ struct StopNotifications: BluetoothAction {
 
     func execute(state: BluetoothState, client: any BluetoothClient) async throws -> CharacteristicResponse {
         let peripheral = try await state.getConnectedPeripheral(request.peripheralId)
-        let characteristic = try await state.getCharacteristic(peripheralId: request.peripheralId, serviceId: request.serviceUuid, characteristicId: request.characteristicUuid, instance: request.characteristicInstance)
-        _ = try await client.characteristicSetNotifications(peripheral, characteristic: characteristic, enable: false)
+        let (service, characteristic) = try await state.getCharacteristic(peripheralId: request.peripheralId, serviceId: request.serviceUuid, characteristicId: request.characteristicUuid, instance: request.characteristicInstance)
+        _ = try await client.characteristicSetNotifications(peripheral, service: service, characteristic: characteristic, enable: false)
         return CharacteristicResponse()
     }
 }

--- a/lib/Sources/BluetoothAction/WriteCharacteristic.swift
+++ b/lib/Sources/BluetoothAction/WriteCharacteristic.swift
@@ -48,7 +48,7 @@ struct WriteCharacteristic: BluetoothAction {
 
     func execute(state: BluetoothState, client: BluetoothClient) async throws -> CharacteristicResponse {
         let peripheral = try await state.getConnectedPeripheral(request.peripheralId)
-        let characteristic = try await state.getCharacteristic(
+        let (service, characteristic) = try await state.getCharacteristic(
             peripheralId: request.peripheralId,
             serviceId: request.serviceUuid,
             characteristicId: request.characteristicUuid,
@@ -61,7 +61,7 @@ struct WriteCharacteristic: BluetoothAction {
                 // The peripheral state is false, waiting until the delegate callback updates it to true...
             }
         }
-        _ = try await client.characteristicWrite(peripheral, characteristic: characteristic, value: request.value, withResponse: request.withResponse)
+        _ = try await client.characteristicWrite(peripheral, service: service, characteristic: characteristic, value: request.value, withResponse: request.withResponse)
         return CharacteristicResponse()
     }
 }

--- a/lib/Sources/BluetoothClient/BluetoothClient.swift
+++ b/lib/Sources/BluetoothClient/BluetoothClient.swift
@@ -20,8 +20,8 @@ public protocol BluetoothClient: Sendable {
     func discoverServices(_ peripheral: Peripheral, filter: ServiceDiscoveryFilter) async throws -> ServiceDiscoveryEvent
     func discoverCharacteristics(_ peripheral: Peripheral, filter: CharacteristicDiscoveryFilter) async throws -> CharacteristicDiscoveryEvent
     func discoverDescriptors(_ peripheral: Peripheral, characteristic: Characteristic) async throws -> DescriptorDiscoveryEvent
-    func characteristicSetNotifications(_ peripheral: Peripheral, characteristic: Characteristic, enable: Bool) async throws -> CharacteristicEvent
-    func characteristicRead(_ peripheral: Peripheral, characteristic: Characteristic) async throws -> CharacteristicChangedEvent
-    func characteristicWrite(_ peripheral: Peripheral, characteristic: Characteristic, value: Data, withResponse: Bool) async throws -> CharacteristicEvent
+    func characteristicSetNotifications(_ peripheral: Peripheral, service: Service, characteristic: Characteristic, enable: Bool) async throws -> CharacteristicEvent
+    func characteristicRead(_ peripheral: Peripheral, service: Service, characteristic: Characteristic) async throws -> CharacteristicChangedEvent
+    func characteristicWrite(_ peripheral: Peripheral, service: Service, characteristic: Characteristic, value: Data, withResponse: Bool) async throws -> CharacteristicEvent
     func descriptorRead(_ peripheral: Peripheral, characteristic: Characteristic, descriptor: Descriptor) async throws -> DescriptorChangedEvent
 }

--- a/lib/Sources/BluetoothClient/Events/CharacteristicChangedEvent.swift
+++ b/lib/Sources/BluetoothClient/Events/CharacteristicChangedEvent.swift
@@ -3,18 +3,20 @@ import Foundation
 
 public struct CharacteristicChangedEvent: BluetoothEvent {
     public let peripheralId: UUID
+    public let serviceId: UUID
     public let characteristicId: UUID
     public let instance: UInt32
     public let data: Data?
 
-    public init(peripheralId: UUID, characteristicId: UUID, instance: UInt32, data: Data?) {
+    public init(peripheralId: UUID, serviceId: UUID, characteristicId: UUID, instance: UInt32, data: Data?) {
         self.peripheralId = peripheralId
+        self.serviceId = serviceId
         self.characteristicId = characteristicId
         self.instance = instance
         self.data = data
     }
 
     public var lookup: EventLookup {
-        .exact(key: .characteristic(.characteristicValue, peripheralId: peripheralId, characteristicId: characteristicId, instance: instance))
+        .exact(key: .characteristic(.characteristicValue, peripheralId: peripheralId, serviceId: serviceId, characteristicId: characteristicId, instance: instance))
     }
 }

--- a/lib/Sources/BluetoothClient/Events/CharacteristicEvent.swift
+++ b/lib/Sources/BluetoothClient/Events/CharacteristicEvent.swift
@@ -4,27 +4,29 @@ import Foundation
 public struct CharacteristicEvent: BluetoothEvent {
     public let name: EventName
     public let peripheralId: UUID
+    public let serviceId: UUID
     public let characteristicId: UUID
     public let instance: UInt32
 
-    public init(_ name: EventName, peripheralId: UUID, characteristicId: UUID, instance: UInt32) {
+    public init(_ name: EventName, peripheralId: UUID, serviceId: UUID, characteristicId: UUID, instance: UInt32) {
         self.name = name
         self.peripheralId = peripheralId
+        self.serviceId = serviceId
         self.characteristicId = characteristicId
         self.instance = instance
     }
 
     public var lookup: EventLookup {
-        .exact(key: .characteristic(name, peripheralId: peripheralId, characteristicId: characteristicId, instance: instance))
+        .exact(key: .characteristic(name, peripheralId: peripheralId, serviceId: serviceId, characteristicId: characteristicId, instance: instance))
     }
 }
 
 extension EventRegistrationKey {
-    public static func characteristic(_ name: EventName, peripheralId: UUID, characteristicId: UUID, instance: UInt32) -> Self {
+    public static func characteristic(_ name: EventName, peripheralId: UUID, serviceId: UUID, characteristicId: UUID, instance: UInt32) -> Self {
         EventRegistrationKey(
             name: name,
             peripheralId: peripheralId,
-            // TODO: should we have serviceId here also?
+            serviceId: serviceId,
             characteristicId: characteristicId,
             characteristicInstance: instance
         )

--- a/lib/Sources/BluetoothClient/Mocks/MockClient.swift
+++ b/lib/Sources/BluetoothClient/Mocks/MockClient.swift
@@ -99,15 +99,15 @@ public struct MockBluetoothClient: BluetoothClient {
         try await onDiscoverDescriptors(peripheral, characteristic)
     }
 
-    public func characteristicSetNotifications(_ peripheral: Peripheral, characteristic: Bluetooth.Characteristic, enable: Bool) async throws -> CharacteristicEvent {
+    public func characteristicSetNotifications(_ peripheral: Peripheral, service: Service, characteristic: Characteristic, enable: Bool) async throws -> CharacteristicEvent {
         try await onCharacteristicSetNotifications(peripheral, characteristic, enable)
     }
 
-    public func characteristicRead(_ peripheral: Peripheral, characteristic: Characteristic) async throws -> CharacteristicChangedEvent {
+    public func characteristicRead(_ peripheral: Peripheral, service: Service, characteristic: Characteristic) async throws -> CharacteristicChangedEvent {
         try await onCharacteristicRead(peripheral, characteristic)
     }
 
-    public func characteristicWrite(_ peripheral: Peripheral, characteristic: Characteristic, value: Data, withResponse: Bool) async throws -> CharacteristicEvent {
+    public func characteristicWrite(_ peripheral: Peripheral, service: Service, characteristic: Characteristic, value: Data, withResponse: Bool) async throws -> CharacteristicEvent {
         try await onCharacteristicWrite(peripheral, characteristic, value, withResponse)
     }
 

--- a/lib/Sources/BluetoothMessage/BluetoothState.swift
+++ b/lib/Sources/BluetoothMessage/BluetoothState.swift
@@ -53,7 +53,10 @@ public actor BluetoothState {
         return deadPeripherals
     }
 
-    public func putPeripheral(_ peripheral: Peripheral) {
+    public func putPeripheral(_ peripheral: Peripheral, replace: Bool) {
+        guard replace || peripherals.index(forKey: peripheral.id) == nil else {
+            return
+        }
         self.peripherals[peripheral.id] = peripheral
     }
 
@@ -101,12 +104,12 @@ public actor BluetoothState {
         self.peripherals[peripheralId]?.services = services
     }
 
-    public func getCharacteristic(peripheralId uuid: UUID, serviceId: UUID, characteristicId: UUID, instance: UInt32) throws -> Characteristic {
+    public func getCharacteristic(peripheralId uuid: UUID, serviceId: UUID, characteristicId: UUID, instance: UInt32) throws -> (Service, Characteristic) {
         let service = try getService(peripheralId: uuid, serviceId: serviceId)
         guard let characteristic = service.characteristics.first(where: { $0.uuid == characteristicId && $0.instance == instance }) else {
             throw BluetoothError.noSuchCharacteristic(service: serviceId, characteristic: characteristicId)
         }
-        return characteristic
+        return (service, characteristic)
     }
 
     public func getCharacteristics(peripheralId uuid: UUID, serviceId: UUID) throws -> [Characteristic] {

--- a/lib/Sources/BluetoothNative/NativeClient.swift
+++ b/lib/Sources/BluetoothNative/NativeClient.swift
@@ -90,29 +90,54 @@ struct NativeBluetoothClient: BluetoothClient {
         }
     }
 
-    func characteristicSetNotifications(_ peripheral: Peripheral, characteristic: Characteristic, enable: Bool) async throws -> CharacteristicEvent {
-        try await server.awaitEvent(key: .characteristic(.characteristicNotify, peripheralId: peripheral.id, characteristicId: characteristic.uuid, instance: characteristic.instance)) {
+    func characteristicSetNotifications(_ peripheral: Peripheral, service: Service, characteristic: Characteristic, enable: Bool) async throws -> CharacteristicEvent {
+        try await server.awaitEvent(
+            key: .characteristic(
+                .characteristicNotify,
+                peripheralId: peripheral.id,
+                serviceId: service.uuid,
+                characteristicId: characteristic.uuid,
+                instance: characteristic.instance
+            )
+        ) {
             coordinator.setNotify(peripheral: peripheral, characteristic: characteristic, value: enable)
         }
     }
 
-    func characteristicWrite(_ peripheral: Peripheral, characteristic: Characteristic, value: Data, withResponse: Bool) async throws -> CharacteristicEvent {
+    func characteristicWrite(_ peripheral: Peripheral, service: Service, characteristic: Characteristic, value: Data, withResponse: Bool) async throws -> CharacteristicEvent {
         guard withResponse else {
             coordinator.writeCharacteristic(peripheral: peripheral, characteristic: characteristic, value: value, withResponse: withResponse)
             return CharacteristicEvent(
                 .characteristicWrite,
                 peripheralId: peripheral.id,
+                serviceId: service.uuid,
                 characteristicId: characteristic.uuid,
                 instance: characteristic.instance
             )
         }
-        return try await server.awaitEvent(key: .characteristic(.characteristicWrite, peripheralId: peripheral.id, characteristicId: characteristic.uuid, instance: characteristic.instance)) {
+        return try await server.awaitEvent(
+            key: .characteristic(
+                .characteristicWrite,
+                peripheralId: peripheral.id,
+                serviceId: service.uuid,
+                characteristicId: characteristic.uuid,
+                instance: characteristic.instance
+            )
+        ) {
             coordinator.writeCharacteristic(peripheral: peripheral, characteristic: characteristic, value: value, withResponse: withResponse)
         }
     }
 
-    func characteristicRead(_ peripheral: Peripheral, characteristic: Characteristic) async throws -> CharacteristicChangedEvent {
-        return try await server.awaitEvent(key: .characteristic(.characteristicValue, peripheralId: peripheral.id, characteristicId: characteristic.uuid, instance: characteristic.instance)) {
+    func characteristicRead(_ peripheral: Peripheral, service: Service, characteristic: Characteristic) async throws -> CharacteristicChangedEvent {
+        return try await server.awaitEvent(
+            key: .characteristic(
+                .characteristicValue,
+                peripheralId: peripheral.id,
+                serviceId: service.uuid,
+                characteristicId: characteristic.uuid,
+                instance: characteristic.instance
+            )
+        ) {
             coordinator.readCharacteristic(peripheral: peripheral, characteristic: characteristic)
         }
     }

--- a/lib/Sources/WebView/Resources/Generated/BluetoothPolyfill.js
+++ b/lib/Sources/WebView/Resources/Generated/BluetoothPolyfill.js
@@ -450,22 +450,11 @@ class Store {
             }
             serviceRecord.characteristics.set(keyForCharacteristic(characteristic), { uuid: characteristic.uuid, characteristic, descriptors: new Map() });
         };
-        this.findCharacteristic = (key) => {
-            var _a;
-            for (const deviceRecord of __classPrivateFieldGet(this, _Store_devices, "f").values()) {
-                for (const serviceRecord of deviceRecord.services.values()) {
-                    const characteristic = (_a = serviceRecord.characteristics.get(key)) === null || _a === void 0 ? void 0 : _a.characteristic;
-                    if (characteristic) {
-                        return characteristic;
-                    }
-                }
-            }
-            return undefined;
-        };
-        this.updateCharacteristicValue = (key, value) => {
-            const characteristic = this.findCharacteristic(key);
+        this.updateCharacteristicValue = (deviceUuid, serviceUuid, uuid, instance, value) => {
+            var _a, _b, _c;
+            const characteristic = (_c = (_b = (_a = __classPrivateFieldGet(this, _Store_devices, "f").get(deviceUuid)) === null || _a === void 0 ? void 0 : _a.services.get(serviceUuid)) === null || _b === void 0 ? void 0 : _b.characteristics.get(characteristicKey(uuid, instance))) === null || _c === void 0 ? void 0 : _c.characteristic;
             if (!characteristic) {
-                throw new ReferenceError(`Characteristic ${key} not found`);
+                throw new ReferenceError(`Characteristic ${uuid} not found`);
             }
             characteristic.value = value;
             return characteristic;
@@ -794,6 +783,13 @@ class ValueEvent extends Event {
     }
 }
 
+const convertToCharacteristicEvent = (event) => {
+    const payload = event.data;
+    const data = base64ToDataView(payload.value);
+    const characteristic = store.updateCharacteristicValue(payload.device, payload.service, payload.characteristic, payload.instance, data);
+    return { characteristic, event: new ValueEvent(event.name, { value: data }) };
+};
+
 const processEvent = (event) => {
     let eventToSend;
     let targets = [];
@@ -812,10 +808,9 @@ const processEvent = (event) => {
         pushDeviceTarget();
     }
     else if (event.name === 'characteristicvaluechanged') {
-        const data = base64ToDataView(event.data);
-        const characteristic = store.updateCharacteristicValue(event.id, data);
-        targets.push(characteristic);
-        eventToSend = new ValueEvent(event.name, { value: data });
+        const characteristicEvent = convertToCharacteristicEvent(event);
+        targets.push(characteristicEvent.characteristic);
+        eventToSend = characteristicEvent.event;
     }
     else if (event.name === 'advertisementreceived') {
         eventToSend = convertToAdvertisingEvent(event);
@@ -857,10 +852,10 @@ const percentInterpolation = (format, args) => {
     if (args.length === 0) {
         return format;
     }
-    if (!/%s|%v|%d|%f/.test(format)) {
+    if (!/%s|%v|%o|%d|%i|%f/.test(format)) {
         return;
     }
-    return args.reduce((str, val) => str.replace(/%s|%v|%d|%f/, val), format);
+    return args.reduce((str, val) => str.replace(/%s|%v|%o|%d|%i|%f/, val), format);
 };
 const logOverride = (level, args) => {
     if (args.length === 0) {

--- a/lib/Tests/BluetoothEngineTests/BluetoothEngineTests.swift
+++ b/lib/Tests/BluetoothEngineTests/BluetoothEngineTests.swift
@@ -71,7 +71,7 @@ struct BluetoothEngineTests {
             client.onEnable = { }
             client.onConnect = { PeripheralEvent(.connect, $0) }
             await state.setSystemState(.poweredOn)
-            await state.putPeripheral(fake)
+            await state.putPeripheral(fake, replace: true)
         }
         await sut.didAttach(to: context)
         let message = Message(action: .connect, requestBody: connectRequestBody)
@@ -95,7 +95,7 @@ struct BluetoothEngineTests {
             client.onEnable = { }
             client.onDisconnect = { PeripheralEvent(.disconnect, $0) }
             await state.setSystemState(.poweredOn)
-            await state.putPeripheral(fake)
+            await state.putPeripheral(fake, replace: true)
         }
         await sut.didAttach(to: context)
         let message = Message(action: .disconnect, requestBody: disconnectRequestBody)
@@ -124,7 +124,7 @@ struct BluetoothEngineTests {
             client.onEnable = { }
             client.onDiscoverServices = { peripheral, _ in ServiceDiscoveryEvent(peripheralId: peripheral.id, services: expectedServices) }
             await state.setSystemState(.poweredOn)
-            await state.putPeripheral(fake)
+            await state.putPeripheral(fake, replace: true)
         }
         await sut.didAttach(to: context)
         let message = Message(action: .discoverServices, requestBody: requestBody)
@@ -153,7 +153,7 @@ struct BluetoothEngineTests {
             client.onEnable = { }
             client.onDiscoverServices = { peripheral, _ in ServiceDiscoveryEvent(peripheralId: peripheral.id, services: expectedServices) }
             await state.setSystemState(.poweredOn)
-            await state.putPeripheral(fake)
+            await state.putPeripheral(fake, replace: true)
         }
         await sut.didAttach(to: context)
         let message = Message(action: .discoverServices, requestBody: requestBody)
@@ -182,7 +182,7 @@ struct BluetoothEngineTests {
             client.onEnable = { }
             client.onDiscoverServices = { peripheral, _ in ServiceDiscoveryEvent(peripheralId: peripheral.id, services: expectedServices) }
             await state.setSystemState(.poweredOn)
-            await state.putPeripheral(fake)
+            await state.putPeripheral(fake, replace: true)
         }
         await sut.didAttach(to: context)
         let message = Message(action: .discoverServices, requestBody: requestBody)

--- a/lib/Tests/BluetoothEngineTests/ConnectTests.swift
+++ b/lib/Tests/BluetoothEngineTests/ConnectTests.swift
@@ -79,7 +79,7 @@ struct ConnectorTests {
         var client = MockBluetoothClient()
         client.onConnect = { peripheral in
             let connectedPeripheral = FakePeripheral(id: peripheral.id, connectionState: .connected)
-            state.putPeripheral(connectedPeripheral)
+            state.putPeripheral(connectedPeripheral, replace: true)
             return PeripheralEvent(.connect, connectedPeripheral)
         }
         return client

--- a/lib/Tests/BluetoothEngineTests/DiscoverCharacteristicsTests.swift
+++ b/lib/Tests/BluetoothEngineTests/DiscoverCharacteristicsTests.swift
@@ -37,7 +37,7 @@ struct DiscoverCharacteristicsTests {
                 CharacteristicDiscoveryEvent(peripheralId: peripheral.id, serviceId: filter.service, characteristics: expectedCharacteristics)
             }
             await state.setSystemState(.poweredOn)
-            await state.putPeripheral(fake)
+            await state.putPeripheral(fake, replace: true)
         }
         await sut.didAttach(to: context)
         let message = Message(action: .discoverCharacteristics, requestBody: requestBody)
@@ -73,7 +73,7 @@ struct DiscoverCharacteristicsTests {
                 CharacteristicDiscoveryEvent(peripheralId: peripheral.id, serviceId: filter.service, characteristics: expectedCharacteristics)
             }
             await state.setSystemState(.poweredOn)
-            await state.putPeripheral(fake)
+            await state.putPeripheral(fake, replace: true)
         }
         await sut.didAttach(to: context)
         let message = Message(action: .discoverCharacteristics, requestBody: requestBody)
@@ -110,7 +110,7 @@ struct DiscoverCharacteristicsTests {
                 return CharacteristicDiscoveryEvent(peripheralId: peripheral.id, serviceId: filter.service, characteristics: expectedCharacteristics)
             }
             await state.setSystemState(.poweredOn)
-            await state.putPeripheral(fake)
+            await state.putPeripheral(fake, replace: true)
         }
         await sut.didAttach(to: context)
         let message = Message(action: .discoverCharacteristics, requestBody: requestBody)

--- a/lib/Tests/BluetoothEngineTests/EndToEndTests.swift
+++ b/lib/Tests/BluetoothEngineTests/EndToEndTests.swift
@@ -14,6 +14,7 @@ import XCTest
 struct EndToEndBluetoothEngineTests {
 
     private let zeroUuid: UUID! = UUID(uuidString: "00000000-0000-0000-0000-000000000000")
+    private let fakeServiceId = UUID(n: 9)
 
     private let requestDeviceRequest = JsMessageRequest(
         handlerName: "bluetooth",
@@ -85,7 +86,7 @@ struct EndToEndBluetoothEngineTests {
         let sut = BluetoothEngine(state: state, client: client, deviceSelector: await TestDeviceSelector())
         await sut.didAttach(to: context)
         client.eventsContinuation.yield(
-            CharacteristicChangedEvent(peripheralId: fake.id, characteristicId: characteristic.uuid, instance: characteristic.instance, data: nil)
+            CharacteristicChangedEvent(peripheralId: fake.id, serviceId: fakeServiceId, characteristicId: characteristic.uuid, instance: characteristic.instance, data: nil)
         )
 
         // It is critical that Js sees the `characteristicvaluechanged` event before the promise is resolved

--- a/lib/Tests/BluetoothEngineTests/StartNotificationsTests.swift
+++ b/lib/Tests/BluetoothEngineTests/StartNotificationsTests.swift
@@ -25,7 +25,7 @@ struct StartNotificationsTests {
 
     @Test
     func execute_withBasicPeripheral_clientShouldStartNotifications() async throws {
-        let basicCharacteristic = CharacteristicEvent(.characteristicNotify, peripheralId: fakePeripheralId, characteristicId: fakeCharacteristicUuid, instance: fakeCharacteristicInstance)
+        let basicCharacteristic = CharacteristicEvent(.characteristicNotify, peripheralId: fakePeripheralId, serviceId: fakeServiceUuid, characteristicId: fakeCharacteristicUuid, instance: fakeCharacteristicInstance)
         let startInvokedExpectation = XCTestExpectation(description: "onStartNotifications invoked")
         let mockBluetoothClient = mockBluetoothClient {
             $0.onCharacteristicSetNotifications = { _, _, startNotifying in
@@ -133,7 +133,7 @@ struct StartNotificationsTests {
     @Test
     func execute_characteristicIsAlreadyNotifying_clientShouldNotStartNotifications() async throws {
         let alreadyNotifyingCharacteristic = FakeCharacteristic(uuid: fakeCharacteristicUuid, instance: fakeCharacteristicInstance, properties: [.notify, .indicate], isNotifying: true)
-        let basicCharacteristic = CharacteristicEvent(.characteristicNotify, peripheralId: fakePeripheralId, characteristicId: fakeCharacteristicUuid, instance: fakeCharacteristicInstance)
+        let basicCharacteristic = CharacteristicEvent(.characteristicNotify, peripheralId: fakePeripheralId, serviceId: fakeServiceUuid, characteristicId: fakeCharacteristicUuid, instance: fakeCharacteristicInstance)
         let startInvokedExpectation = XCTestExpectation(description: "onStartNotifications invoked")
         startInvokedExpectation.isInverted = true
         let mockBluetoothClient = mockBluetoothClient {
@@ -157,7 +157,7 @@ struct StartNotificationsTests {
 
 private func mockBluetoothClient(modify: ((inout MockBluetoothClient) -> Void)? = nil) -> MockBluetoothClient {
     var client = MockBluetoothClient()
-    let basicCharacteristic = CharacteristicEvent(.characteristicNotify, peripheralId: fakePeripheralId, characteristicId: fakeCharacteristicUuid, instance: fakeCharacteristicInstance)
+    let basicCharacteristic = CharacteristicEvent(.characteristicNotify, peripheralId: fakePeripheralId, serviceId: fakeServiceUuid, characteristicId: fakeCharacteristicUuid, instance: fakeCharacteristicInstance)
     client.onCharacteristicSetNotifications = { _, _, _ in
         basicCharacteristic
     }

--- a/lib/Tests/BluetoothEngineTests/StopNotificationsTests.swift
+++ b/lib/Tests/BluetoothEngineTests/StopNotificationsTests.swift
@@ -25,7 +25,7 @@ struct StopNotificationsTests {
 
     @Test
     func execute_withBasicPeripheral_clientShouldStopNotifications() async throws {
-        let basicCharacteristic = CharacteristicEvent(.characteristicNotify, peripheralId: fakePeripheralId, characteristicId: fakeCharacteristicUuid, instance: fakeCharacteristicInstance)
+        let basicCharacteristic = CharacteristicEvent(.characteristicNotify, peripheralId: fakePeripheralId, serviceId: fakeServiceUuid, characteristicId: fakeCharacteristicUuid, instance: fakeCharacteristicInstance)
         let stopInvokedExpectation = XCTestExpectation(description: "onStopNotifications invoked")
         let mockBluetoothClient = mockBluetoothClient {
             $0.onCharacteristicSetNotifications = { _, _, startNotifying in
@@ -76,7 +76,7 @@ struct StopNotificationsTests {
 
 private func mockBluetoothClient(modify: ((inout MockBluetoothClient) -> Void)? = nil) -> MockBluetoothClient {
     var client = MockBluetoothClient()
-    let basicCharacteristic = CharacteristicEvent(.characteristicNotify, peripheralId: fakePeripheralId, characteristicId: fakeCharacteristicUuid, instance: fakeCharacteristicInstance)
+    let basicCharacteristic = CharacteristicEvent(.characteristicNotify, peripheralId: fakePeripheralId, serviceId: fakeServiceUuid, characteristicId: fakeCharacteristicUuid, instance: fakeCharacteristicInstance)
     client.onCharacteristicSetNotifications = { _, _, _ in
         basicCharacteristic
     }


### PR DESCRIPTION
Two separate bugs, both manifest as the same problem where characteristic events do not arrive on the Js side:

1. when scanning existing peripherals in the store would get clobbered with new ones, so if one was already there with discovered services, it would be replaced with one _without_ any services
2. if you connect two peripherals with identical characteristics, the characteristic events from the delegate would be routed to the wrong one because we were not providing a unique lookup key with the event

Unrelated patches to some logging:
- add '%d' and '%o' to the Js log interpolation
- log the details for responses with an error payload 
