### PR TITLE
Fix manufacturer and service data filtering for device picker

### DIFF
--- a/lib/Sources/BluetoothAction/Options+Decode.swift
+++ b/lib/Sources/BluetoothAction/Options+Decode.swift
@@ -131,11 +131,11 @@ extension [JsType] {
 
 extension Dictionary where Key == String, Value == JsType {
     func compactMapToUint8Array() -> [UInt8]? {
-        self.sorted(by: { $0.key < $1.key }).compactMap { $0.value.number }.compactMap { UInt8(truncating: $0) }
+        self.sorted(by: { $0.key < $1.key }).compactMap { $0.value.number.map(UInt8.init(truncating:)) }
     }
 
     func compactMapToUint16Array() -> [UInt16]? {
-        self.sorted(by: { $0.key < $1.key }).compactMap { $0.value.number }.compactMap { UInt16(truncating: $0) }
+        self.sorted(by: { $0.key < $1.key }).compactMap { $0.value.number.map(UInt16.init(truncating:)) }
     }
 }
 

--- a/lib/Sources/BluetoothAction/Options+Decode.swift
+++ b/lib/Sources/BluetoothAction/Options+Decode.swift
@@ -22,7 +22,7 @@ extension Options {
         let filters = try data?[filtersKey]?.array?.compactMap { try Options.Filter.decode(from: $0.dictionary) }.nilIfEmpty()
         let exclusionFilters = try data?[exclusionFiltersKey]?.array?.compactMap { try Options.Filter.decode(from: $0.dictionary) }
         let optionalServices = data?[optionalServicesKey]?.array?.compactMapToUUIDs()
-        let optionalManufacturerData = data?[optionalManufacturerDataKey]?.array?.compactMapToUint16Array()
+        let optionalManufacturerData = data?[optionalManufacturerDataKey]?.dictionary?.compactMapToUint16Array()
         let acceptAllDevices = data?[acceptAllDevicesKey]?.number?.boolValue ?? false
 
         guard filters != nil || exclusionFilters != nil || optionalServices != nil || optionalManufacturerData != nil || acceptAllDevices else {
@@ -89,9 +89,9 @@ extension Options.Filter.ManufacturerData {
             return nil
         }
 
-        let dataPrefix = data?[dataPrefixKey]?.array?.compactMapToUint8Array()
+        let dataPrefix = data?[dataPrefixKey]?.dictionary?.compactMapToUint8Array()
 
-        let mask = data?[maskKey]?.array?.compactMapToUint8Array()
+        let mask = data?[maskKey]?.dictionary?.compactMapToUint8Array()
 
         if mask != nil {
             guard dataPrefix != nil else {
@@ -109,9 +109,9 @@ extension Options.Filter.ServiceData {
             return nil
         }
 
-        let dataPrefix = data?[dataPrefixKey]?.array?.compactMapToUint8Array()
+        let dataPrefix = data?[dataPrefixKey]?.dictionary?.compactMapToUint8Array()
 
-        let mask = data?[maskKey]?.array?.compactMapToUint8Array()
+        let mask = data?[maskKey]?.dictionary?.compactMapToUint8Array()
 
         if mask != nil {
             guard dataPrefix != nil else {
@@ -127,13 +127,15 @@ extension [JsType] {
     func compactMapToUUIDs() -> [UUID]? {
         self.compactMap { $0.string.toUuid() }
     }
+}
 
+extension Dictionary where Key == String, Value == JsType {
     func compactMapToUint8Array() -> [UInt8]? {
-        self.compactMap { $0.number }.compactMap { UInt8(truncating: $0) }
+        self.sorted(by: { $0.key < $1.key }).compactMap { $0.value.number }.compactMap { UInt8(truncating: $0) }
     }
 
     func compactMapToUint16Array() -> [UInt16]? {
-        self.compactMap { $0.number }.compactMap { UInt16(truncating: $0) }
+        self.sorted(by: { $0.key < $1.key }).compactMap { $0.value.number }.compactMap { UInt16(truncating: $0) }
     }
 }
 

--- a/lib/Tests/BluetoothEngineTests/Options+DecodeTests.swift
+++ b/lib/Tests/BluetoothEngineTests/Options+DecodeTests.swift
@@ -307,7 +307,7 @@ struct Options_DecodeTests {
     @Test
     func decode_example4_5_returnsCorrectOptionsObject() {
         // { filters: [{ manufacturerData: [{ companyIdentifier: 17, dataPrefix: Uint8Array([1, 2, 3]) }]}] }
-        let web_bluetooth_options = ["filters": JsType.bridge([["manufacturerData": [["companyIdentifier": 7351, "dataPrefix": [1, 2, 3]]]]])]
+        let web_bluetooth_options = ["filters": JsType.bridge([["manufacturerData": [["companyIdentifier": 7351, "dataPrefix": ["1": 2, "2": 3, "0": 1]]]]])]
 
         #expect(throws: Never.self) {
             let result = try sut.decode(from: web_bluetooth_options)
@@ -326,7 +326,7 @@ struct Options_DecodeTests {
     @Test
     func decode_example4_6_returnsCorrectOptionsObject() {
         // { filters: [{ manufacturerData: [{ companyIdentifier: 17, dataPrefix: Uint8Array([1, 2, 3, 4]) }]}] }
-        let web_bluetooth_options = ["filters": JsType.bridge([["manufacturerData": [["companyIdentifier": 7351, "dataPrefix": [1, 2, 3, 4]]]]])]
+        let web_bluetooth_options = ["filters": JsType.bridge([["manufacturerData": [["companyIdentifier": 7351, "dataPrefix": ["0": 1, "1": 2, "3": 4, "2": 3]]]]])]
 
         #expect(throws: Never.self) {
             let result = try sut.decode(from: web_bluetooth_options)
@@ -345,7 +345,7 @@ struct Options_DecodeTests {
     @Test
     func decode_example4_7_returnsCorrectOptionsObject() {
         // { filters: [{ manufacturerData: [{ companyIdentifier: 17, dataPrefix: Uint8Array([1]) }]}] }
-        let web_bluetooth_options = ["filters": JsType.bridge([["manufacturerData": [["companyIdentifier": 7351, "dataPrefix": [1]]]]])]
+        let web_bluetooth_options = ["filters": JsType.bridge([["manufacturerData": [["companyIdentifier": 7351, "dataPrefix": ["0": 1]]]]])]
 
         #expect(throws: Never.self) {
             let result = try sut.decode(from: web_bluetooth_options)
@@ -364,7 +364,7 @@ struct Options_DecodeTests {
     @Test
     func decode_example4_8_returnsCorrectOptionsObject() {
         // { filters: [{ manufacturerData: [{ companyIdentifier: 17, dataPrefix: Uint8Array([0x91, 0xAA]), mask: Uint8Array([0x0f, 0x57])}]}] }
-        let web_bluetooth_options = ["filters": JsType.bridge([["manufacturerData": [["companyIdentifier": 7351, "dataPrefix": [0x91, 0xAA], "mask": [0x0f, 0x57]]]]])]
+        let web_bluetooth_options = ["filters": JsType.bridge([["manufacturerData": [["companyIdentifier": 7351, "dataPrefix": ["0": 0x91, "1": 0xAA], "mask": ["0": 0x0f, "1": 0x57]]]]])]
 
         #expect(throws: Never.self) {
             let result = try sut.decode(from: web_bluetooth_options)
@@ -511,7 +511,7 @@ struct Options_DecodeTests {
     @Test
     func decode_providesMaskInManufacturerDataButNoDataPrefix_throwsInvalidInputError() {
         // { filters: [{ manufacturerData: [{ companyIdentifier: 17, mask: Uint8Array([0x0f, 0x57])}]}] }
-        let web_bluetooth_options = ["filters": JsType.bridge([["manufacturerData": [["companyIdentifier": 7351, "mask": [0x0f, 0x57]]]]])]
+        let web_bluetooth_options = ["filters": JsType.bridge([["manufacturerData": [["companyIdentifier": 7351, "mask": ["1": 0x57, "0": 0x0f]]]]])]
 
         #expect(throws: OptionsError.invalidInput("manufacturerData.mask, if provided, must also have a dataPrefix")) {
             try sut.decode(from: web_bluetooth_options)
@@ -521,7 +521,7 @@ struct Options_DecodeTests {
     @Test
     func decode_providesMaskInServiceDataButNoDataPrefix_throwsInvalidInputError() {
         // { filters: [{ serviceData: [{ service: "A", mask: Uint8Array([0x0f, 0x57]) }] }] }
-        let web_bluetooth_options = ["filters": JsType.bridge([["serviceData": [["service": uuid_1.uuidString, "mask": [0x0f, 0x57]]]]])]
+        let web_bluetooth_options = ["filters": JsType.bridge([["serviceData": [["service": uuid_1.uuidString, "mask": ["0": 0x0f, "1": 0x57]]]]])]
 
         #expect(throws: OptionsError.invalidInput("serviceData.mask, if provided, must also have a dataPrefix")) {
             try sut.decode(from: web_bluetooth_options)
@@ -531,7 +531,7 @@ struct Options_DecodeTests {
     @Test
     func decode_fullServiceDataFilter_returnsCorrectOptionsObject() {
         // { filters: [{ serviceData: [{ service: "A", dataPrefix: Uint8Array([0x91, 0xAA]), mask: Uint8Array([0x0f, 0x57]) }] }] }
-        let web_bluetooth_options = ["filters": JsType.bridge([["serviceData": [["service": uuid_1.uuidString, "dataPrefix": [0x91, 0xAA], "mask": [0x0f, 0x57]]]]])]
+        let web_bluetooth_options = ["filters": JsType.bridge([["serviceData": [["service": uuid_1.uuidString, "dataPrefix": ["0": 0x91, "1": 0xAA], "mask": ["1": 0x57, "0": 0x0f]]]]])]
 
         #expect(throws: Never.self) {
             let result = try sut.decode(from: web_bluetooth_options)
@@ -551,7 +551,7 @@ struct Options_DecodeTests {
     @Test
     func decode_optionalManufacturerData_returnsCorrectOptionsObject() {
         // { optionalManufacturerData: [1, 2, 3, 4] }
-        let web_bluetooth_options = ["optionalManufacturerData": JsType.bridge([1, 2, 3, 4])]
+        let web_bluetooth_options = ["optionalManufacturerData": JsType.bridge(["0": 1, "1": 2, "2": 3, "3": 4])]
 
         #expect(throws: Never.self) {
             let result = try sut.decode(from: web_bluetooth_options)


### PR DESCRIPTION
Topaz expected the manufacturer and service data byte **array**s to be, well, _arrays_, but apparently JavaScript arrays serialize/stringify to maps (with keys being the indices as strings): 🤦 

![Screenshot 2025-03-27 at 10 04 03 AM](https://github.com/user-attachments/assets/5f44a740-299f-42b5-9d52-768d288a48a1)

This was causing Topaz to always see `dataPrefix` and `mask` for these filters to always be `nil`.

Example payload of a `requestDevice` call (log from Topaz):

![Screenshot 2025-03-27 at 10 15 08 AM](https://github.com/user-attachments/assets/f4a61b21-a1f0-412a-bb77-1b815eaf3659)