### PR TITLE
Zombie detection and cleanup

### DIFF
--- a/lib/Sources/BluetoothEngine/BluetoothEngine.swift
+++ b/lib/Sources/BluetoothEngine/BluetoothEngine.swift
@@ -23,6 +23,7 @@ public actor BluetoothEngine: JsMessageProcessor {
     private let deviceSelector: InteractiveDeviceSelector
     private var jsEventForwarder: JsEventForwarder
     private var task: Task<Void, Never>?
+    private var zombieDetector: ZombieDetector
 
     public init(
         state: BluetoothState,
@@ -35,16 +36,27 @@ public actor BluetoothEngine: JsMessageProcessor {
         self.deviceSelector = deviceSelector
         self.enableDebugLogging = enableDebugLogging
         self.jsEventForwarder = JsEventForwarder { _ in }
+        self.zombieDetector = ZombieDetector(state: state)
     }
 
     // MARK: - Bluetooth Events
 
     private func handleDelegateEvent(_ event: BluetoothEvent) async {
         // Note: order of processing is super important here
+        await monitorZombies(for: event)
         await updateState(for: event)
         await sendJsEvent(for: event)
         await client.resolvePendingRequests(for: event)
         await handleUnexpectedDisconnect(for: event)
+    }
+
+    private func monitorZombies(for event: BluetoothEvent) async {
+        zombieDetector.trackZombies(for: event)
+        for zombie in await zombieDetector.zombies(for: event) {
+            // Propagate a synthetic disconnection event back through the entire system
+            messageLog.warning("Cleaning out zombie peripheral \(zombie.id.uuidString, privacy: .public)")
+            await handleDelegateEvent(DisconnectionEvent.unexpected(zombie, BluetoothError.turnedOff))
+        }
     }
 
     // On unexpected disconnect reject all pending operations for the peripheral

--- a/lib/Sources/BluetoothEngine/BluetoothEngine.swift
+++ b/lib/Sources/BluetoothEngine/BluetoothEngine.swift
@@ -52,7 +52,7 @@ public actor BluetoothEngine: JsMessageProcessor {
 
     private func monitorZombies(for event: BluetoothEvent) async {
         zombieDetector.trackZombies(for: event)
-        for zombie in await zombieDetector.zombies(for: event) {
+        for zombie in await zombieDetector.checkForZombies(for: event) {
             // Propagate a synthetic disconnection event back through the entire system
             messageLog.warning("Cleaning out zombie peripheral \(zombie.id.uuidString, privacy: .public)")
             await handleDelegateEvent(DisconnectionEvent.unexpected(zombie, BluetoothError.turnedOff))

--- a/lib/Sources/BluetoothEngine/ZombieDetector.swift
+++ b/lib/Sources/BluetoothEngine/ZombieDetector.swift
@@ -11,7 +11,7 @@ import Foundation
  Zombies are those with an underlying peripheral state of disconnected where
  we have not seen a disconnect event.
 
- We see this happen when BLE is diabled via Control Center - the peripherals
+ We see this happen when BLE is disabled via Control Center - the peripherals
  silently change to a disconnected state but the delegate never sends a disconnect.
  This is not the case when BLE is disabled via Settings which does the expected
  thing and immediately triggers the delegate to send a disconnect event.
@@ -42,7 +42,7 @@ struct ZombieDetector {
     /// Consult each peripheral to see if we have any zombies that need to be disconnected.
     /// Zombies are those that we think are connected but have been silently disconnected
     /// due to the system being powered off via Control Center.
-    func zombies(for event: BluetoothEvent) async -> [Peripheral] {
+    func checkForZombies(for event: BluetoothEvent) async -> [Peripheral] {
         guard let event = event as? SystemStateEvent, event.systemState == .poweredOff else {
             return []
         }

--- a/lib/Sources/BluetoothEngine/ZombieDetector.swift
+++ b/lib/Sources/BluetoothEngine/ZombieDetector.swift
@@ -1,0 +1,57 @@
+import Bluetooth
+import BluetoothClient
+import BluetoothMessage
+import Foundation
+
+/**
+ The recentlyConnectedPeripherals are those that have successfully been connected.
+ It is updated by connect/disconnect events. We use the mis-match between
+ recentlyConnectedPeripherals and the underlying CBPeripheral.state to
+ recognize when the system has failed to propagate disconnection events.
+ Zombies are those with an underlying peripheral state of disconnected where
+ we have not seen a disconnect event.
+
+ We see this happen when BLE is diabled via Control Center - the peripherals
+ silently change to a disconnected state but the delegate never sends a disconnect.
+ This is not the case when BLE is disabled via Settings which does the expected
+ thing and immediately triggers the delegate to send a disconnect event.
+
+ Tracking issue: rdar://17036865
+ */
+struct ZombieDetector {
+    private let state: BluetoothState
+    private var recentlyConnectedPeripherals: Set<UUID> = []
+
+    init(state: BluetoothState) {
+        self.state = state
+    }
+
+    mutating func trackZombies(for event: BluetoothEvent) {
+        switch event {
+        case let event as PeripheralEvent where event.name == .connect:
+            recentlyConnectedPeripherals.insert(event.peripheral.id)
+        case let DisconnectionEvent.unexpected(peripheral, _):
+            recentlyConnectedPeripherals.remove(peripheral.id)
+        case let DisconnectionEvent.requested(peripheral):
+            recentlyConnectedPeripherals.remove(peripheral.id)
+        default:
+            break
+        }
+    }
+
+    /// Consult each peripheral to see if we have any zombies that need to be disconnected.
+    /// Zombies are those that we think are connected but have been silently disconnected
+    /// due to the system being powered off via Control Center.
+    func zombies(for event: BluetoothEvent) async -> [Peripheral] {
+        guard let event = event as? SystemStateEvent, event.systemState == .poweredOff else {
+            return []
+        }
+        var zombies: [Peripheral] = []
+        for uuid in recentlyConnectedPeripherals {
+            if let peripheral = await state.peripherals[uuid], peripheral.connectionState == .disconnected {
+                zombies.append(peripheral)
+            }
+        }
+        return zombies
+    }
+}

--- a/lib/Tests/BluetoothEngineTests/ZombieDetectorTests.swift
+++ b/lib/Tests/BluetoothEngineTests/ZombieDetectorTests.swift
@@ -12,19 +12,19 @@ struct ZombieDetectorTests {
     private let disconnectedPeripheral = FakePeripheral(id: UUID(n: 0), connectionState: .disconnected)
 
     @Test
-    func zombies_powerOffEventAfterPeripheralConnectedAndNotDisconnected_detectsZombie() async {
+    func checkForZombies_powerOffEventAfterPeripheralConnectedAndNotDisconnected_detectsZombie() async {
         let state = BluetoothState(
             systemState: .poweredOn,
             peripherals: [disconnectedPeripheral]
         )
         var sut = ZombieDetector(state: state)
         sut.trackZombies(for: PeripheralEvent(.connect, connectedPeripheral))
-        let zombies = await sut.zombies(for: SystemStateEvent(.poweredOff))
+        let zombies = await sut.checkForZombies(for: SystemStateEvent(.poweredOff))
         #expect(zombies.count == 1)
     }
 
     @Test
-    func zombies_powerOffEventAfterPeripheralConnectedAndThenRequestedDisconnect_isEmpty() async {
+    func checkForZombies_powerOffEventAfterPeripheralConnectedAndThenRequestedDisconnect_isEmpty() async {
         let state = BluetoothState(
             systemState: .poweredOn,
             peripherals: [disconnectedPeripheral]
@@ -32,12 +32,12 @@ struct ZombieDetectorTests {
         var sut = ZombieDetector(state: state)
         sut.trackZombies(for: PeripheralEvent(.connect, connectedPeripheral))
         sut.trackZombies(for: DisconnectionEvent.requested(disconnectedPeripheral))
-        let zombies = await sut.zombies(for: SystemStateEvent(.poweredOff))
+        let zombies = await sut.checkForZombies(for: SystemStateEvent(.poweredOff))
         #expect(zombies.isEmpty)
     }
 
     @Test
-    func zombies_powerOffEventAfterPeripheralConnectedAndThenUexpectedDisconnect_isEmpty() async {
+    func checkForZombies_powerOffEventAfterPeripheralConnectedAndThenUexpectedDisconnect_isEmpty() async {
         let state = BluetoothState(
             systemState: .poweredOn,
             peripherals: [disconnectedPeripheral]
@@ -45,12 +45,12 @@ struct ZombieDetectorTests {
         var sut = ZombieDetector(state: state)
         sut.trackZombies(for: PeripheralEvent(.connect, connectedPeripheral))
         sut.trackZombies(for: DisconnectionEvent.unexpected(disconnectedPeripheral, BluetoothError.unknown))
-        let zombies = await sut.zombies(for: SystemStateEvent(.poweredOff))
+        let zombies = await sut.checkForZombies(for: SystemStateEvent(.poweredOff))
         #expect(zombies.isEmpty)
     }
 
     @Test
-    func zombies_powerOffEventAfterTwoPeripheralsConnectedAndOneDisconnects_detectsOneZombie() async {
+    func checkForZombies_powerOffEventAfterTwoPeripheralsConnectedAndOneDisconnects_detectsOneZombie() async {
         let state = BluetoothState(
             systemState: .poweredOn,
             peripherals: [
@@ -62,7 +62,7 @@ struct ZombieDetectorTests {
         sut.trackZombies(for: PeripheralEvent(.connect, FakePeripheral(id: UUID(n: 0), connectionState: .connected)))
         sut.trackZombies(for: PeripheralEvent(.connect, FakePeripheral(id: UUID(n: 1), connectionState: .connected)))
         sut.trackZombies(for: DisconnectionEvent.requested(FakePeripheral(id: UUID(n: 0), connectionState: .disconnected)))
-        let zombies = await sut.zombies(for: SystemStateEvent(.poweredOff))
+        let zombies = await sut.checkForZombies(for: SystemStateEvent(.poweredOff))
         #expect(zombies.count == 1)
         #expect(zombies.first?.id == UUID(n: 1))
     }

--- a/lib/Tests/BluetoothEngineTests/ZombieDetectorTests.swift
+++ b/lib/Tests/BluetoothEngineTests/ZombieDetectorTests.swift
@@ -1,0 +1,69 @@
+import Bluetooth
+import BluetoothClient
+@testable import BluetoothEngine
+import BluetoothMessage
+import Foundation
+import Testing
+
+@Suite
+struct ZombieDetectorTests {
+
+    private let connectedPeripheral = FakePeripheral(id: UUID(n: 0), connectionState: .connected)
+    private let disconnectedPeripheral = FakePeripheral(id: UUID(n: 0), connectionState: .disconnected)
+
+    @Test
+    func zombies_powerOffEventAfterPeripheralConnectedAndNotDisconnected_detectsZombie() async {
+        let state = BluetoothState(
+            systemState: .poweredOn,
+            peripherals: [disconnectedPeripheral]
+        )
+        var sut = ZombieDetector(state: state)
+        sut.trackZombies(for: PeripheralEvent(.connect, connectedPeripheral))
+        let zombies = await sut.zombies(for: SystemStateEvent(.poweredOff))
+        #expect(zombies.count == 1)
+    }
+
+    @Test
+    func zombies_powerOffEventAfterPeripheralConnectedAndThenRequestedDisconnect_isEmpty() async {
+        let state = BluetoothState(
+            systemState: .poweredOn,
+            peripherals: [disconnectedPeripheral]
+        )
+        var sut = ZombieDetector(state: state)
+        sut.trackZombies(for: PeripheralEvent(.connect, connectedPeripheral))
+        sut.trackZombies(for: DisconnectionEvent.requested(disconnectedPeripheral))
+        let zombies = await sut.zombies(for: SystemStateEvent(.poweredOff))
+        #expect(zombies.isEmpty)
+    }
+
+    @Test
+    func zombies_powerOffEventAfterPeripheralConnectedAndThenUexpectedDisconnect_isEmpty() async {
+        let state = BluetoothState(
+            systemState: .poweredOn,
+            peripherals: [disconnectedPeripheral]
+        )
+        var sut = ZombieDetector(state: state)
+        sut.trackZombies(for: PeripheralEvent(.connect, connectedPeripheral))
+        sut.trackZombies(for: DisconnectionEvent.unexpected(disconnectedPeripheral, BluetoothError.unknown))
+        let zombies = await sut.zombies(for: SystemStateEvent(.poweredOff))
+        #expect(zombies.isEmpty)
+    }
+
+    @Test
+    func zombies_powerOffEventAfterTwoPeripheralsConnectedAndOneDisconnects_detectsOneZombie() async {
+        let state = BluetoothState(
+            systemState: .poweredOn,
+            peripherals: [
+                FakePeripheral(id: UUID(n: 0), connectionState: .disconnected),
+                FakePeripheral(id: UUID(n: 1), connectionState: .disconnected),
+            ]
+        )
+        var sut = ZombieDetector(state: state)
+        sut.trackZombies(for: PeripheralEvent(.connect, FakePeripheral(id: UUID(n: 0), connectionState: .connected)))
+        sut.trackZombies(for: PeripheralEvent(.connect, FakePeripheral(id: UUID(n: 1), connectionState: .connected)))
+        sut.trackZombies(for: DisconnectionEvent.requested(FakePeripheral(id: UUID(n: 0), connectionState: .disconnected)))
+        let zombies = await sut.zombies(for: SystemStateEvent(.poweredOff))
+        #expect(zombies.count == 1)
+        #expect(zombies.first?.id == UUID(n: 1))
+    }
+}


### PR DESCRIPTION
A workaround for the Core Bluetooth bug on iOS where if BLE is disabled via Control Center we are notified that the system transitions to `poweredOff` and all devices are silently set to a disconnected state, but the system does not emit disconnection events. This zombie detection system monitors all connect/disconnect events and detects this specific situation and then synthesizes the disconnection events so that the Js side can clean up correctly.

Note this only occurs when disabling BLE via Control Center. When disabled via Settings app the disconnection events are emited as expected.
