### PR TITLE
Show bluetooth error banner when in fullscreen

### DIFF
--- a/lib/Sources/App/BluetoothErrorView.swift
+++ b/lib/Sources/App/BluetoothErrorView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct BluetoothErrorView: View {
 
     let state: SystemState
+    let drawShadow: Bool
 
     @Environment(\.openURL) private var openURL
 
@@ -33,9 +34,11 @@ struct BluetoothErrorView: View {
             }
             .padding([.leading, .trailing], 16)
             .padding([.top, .bottom], 12)
-            Rectangle()
-                .frame(maxWidth: .infinity, maxHeight: 0.5)
-                .foregroundStyle(Color.black)
+            if drawShadow {
+                Rectangle()
+                    .frame(maxWidth: .infinity, maxHeight: 0.5)
+                    .foregroundStyle(Color.black)
+            }
         }
         .frame(maxWidth: .infinity)
         .background(Color.topaz800)
@@ -51,7 +54,7 @@ struct BluetoothErrorView: View {
 }
 
 #Preview {
-    BluetoothErrorView(state: .unauthorized)
+    BluetoothErrorView(state: .unauthorized, drawShadow: true)
 #if targetEnvironment(simulator)
         .forceLoadFontsInPreview()
 #endif

--- a/lib/Sources/App/NavBarModel.swift
+++ b/lib/Sources/App/NavBarModel.swift
@@ -1,5 +1,3 @@
-import Bluetooth
-import BluetoothEngine
 import Navigation
 import Observation
 import Settings
@@ -18,10 +16,6 @@ public final class NavBarModel {
 
     var fullscreenButtonDisabled: Bool = false
     var isSettingsPresented: Bool = false
-    var bluetoothSystem: BluetoothSystemState
-    var shouldShowErrorState: Bool {
-        bluetoothSystem.systemState != .unknown && bluetoothSystem.systemState != .poweredOn
-    }
 
     private(set) var isFullscreen: Bool = false
     private let tabManagementAction: () -> Void
@@ -31,7 +25,6 @@ public final class NavBarModel {
         navigator: WebNavigator = WebNavigator(),
         settingsModel: SettingsModel = SettingsModel(),
         searchBarModel: SearchBarModel? = nil,
-        bluetoothSystem: BluetoothSystemState = .shared,
         isFullscreen: Bool = false,
         tabManagementAction: @escaping () -> Void,
         onFullscreenChanged: @escaping (Bool) -> Void
@@ -40,7 +33,6 @@ public final class NavBarModel {
         self.searchBarModel = searchBarModel ?? SearchBarModel(navigator: navigator)
         self.pullDrawer = PullDrawerModel(height: 104.0, ratio: 1.25, activationDistance: 16)
         self.settingsModel = settingsModel
-        self.bluetoothSystem = bluetoothSystem
         self.isFullscreen = isFullscreen
         self.tabManagementAction = tabManagementAction
         self.onFullscreenChanged = onFullscreenChanged

--- a/lib/Sources/App/NavBarView.swift
+++ b/lib/Sources/App/NavBarView.swift
@@ -7,9 +7,6 @@ struct NavBarView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            if model.shouldShowErrorState {
-                BluetoothErrorView(state: model.bluetoothSystem.systemState)
-            }
             if let progress = model.progress {
                 ProgressView(value: progress)
                     .tint(.white)

--- a/lib/Sources/App/WebContainerModel.swift
+++ b/lib/Sources/App/WebContainerModel.swift
@@ -1,3 +1,5 @@
+import Bluetooth
+import BluetoothEngine
 import DevicePicker
 import Observation
 import SwiftUI
@@ -11,10 +13,16 @@ public final class WebContainerModel {
     public var navBarModel: NavBarModel
     public var selector: DeviceSelector
 
+    var bluetoothSystem: BluetoothSystemState
+    var shouldShowErrorState: Bool {
+        bluetoothSystem.systemState != .unknown && bluetoothSystem.systemState != .poweredOn
+    }
+
     init(
         webPageModel: WebPageModel,
         navBarModel: NavBarModel,
-        selector: DeviceSelector
+        selector: DeviceSelector,
+        bluetoothSystem: BluetoothSystemState = .shared
     ) {
         self.webPageModel = webPageModel
         self.navBarModel = navBarModel
@@ -26,5 +34,6 @@ public final class WebContainerModel {
                 selector.cancel()
             }
         )
+        self.bluetoothSystem = bluetoothSystem
     }
 }

--- a/lib/Sources/App/WebContainerView.swift
+++ b/lib/Sources/App/WebContainerView.swift
@@ -21,6 +21,12 @@ struct WebContainerView: View {
                         webContainerModel.navBarModel.fullscreenButtonTapped()
                     }
                 }
+            if webContainerModel.shouldShowErrorState {
+                BluetoothErrorView(
+                    state: webContainerModel.bluetoothSystem.systemState,
+                    drawShadow: !webContainerModel.navBarModel.isFullscreen
+                )
+            }
             if !webContainerModel.navBarModel.isFullscreen {
                 NavBarView(model: webContainerModel.navBarModel)
                 .transition(.move(edge: .bottom).combined(with: .opacity))
@@ -43,12 +49,18 @@ struct WebContainerView: View {
 
 #Preview("DevicePicker") {
     WebContainerView(
-        webContainerModel: previewModel()
+        webContainerModel: previewModel(state: .poweredOn)
+    )
+}
+
+#Preview("PoweredOff") {
+    WebContainerView(
+        webContainerModel: previewModel(state: .poweredOff)
     )
 }
 
 @MainActor
-private func previewModel() -> WebContainerModel {
+private func previewModel(state: SystemState) -> WebContainerModel {
     let url = URL(string: "https://googlechrome.github.io/samples/web-bluetooth/device-info.html")!
     let selector = DeviceSelector()
 #if targetEnvironment(simulator)
@@ -75,7 +87,8 @@ private func previewModel() -> WebContainerModel {
     return WebContainerModel(
         webPageModel: webPageModel,
         navBarModel: navBarModel,
-        selector: selector
+        selector: selector,
+        bluetoothSystem: BluetoothSystemState(systemState: state)
     )
 }
 

--- a/lib/Sources/BluetoothEngine/BluetoothSystemState.swift
+++ b/lib/Sources/BluetoothEngine/BluetoothSystemState.swift
@@ -11,7 +11,7 @@ import Observation
 public final class BluetoothSystemState {
     public private(set) var systemState: SystemState
 
-    init(systemState: SystemState = .unknown) {
+    public init(systemState: SystemState = .unknown) {
         self.systemState = systemState
     }
 


### PR DESCRIPTION
Lift the error view up one level so instead of being part of the `NavBarView` it is on the enclosing `WebContainerView` so it can be presented in both full-screen and non-full-screen modes.

|Preview|
|---|
|<img width="325" alt="ble_off_fullscreen" src="https://github.com/user-attachments/assets/d39dba9c-22b0-40cb-a0af-28c78ef761d7" />|
