### PR TITLE
Reduce size of navigation title

### DIFF
--- a/lib/Sources/Design/Appearance.swift
+++ b/lib/Sources/Design/Appearance.swift
@@ -5,7 +5,7 @@ public extension UINavigationBar {
     static func applyCustomizations() {
         appearance().largeTitleTextAttributes = [
             .foregroundColor: UIColor.white,
-            .font: UIFont.dogpatch(.largeTitle),
+            .font: UIFont.dogpatch(32),
         ]
         appearance().titleTextAttributes = [
             .foregroundColor: UIColor.white,

--- a/lib/Sources/Design/Dogpatch.swift
+++ b/lib/Sources/Design/Dogpatch.swift
@@ -81,6 +81,17 @@ extension Font {
 }
 
 extension UIFont {
+    public static func dogpatch(_ size: CGFloat, weight: Dogpatch.Weight? = nil, design: Dogpatch.Design? = nil) -> UIFont {
+        let design = design ?? .sans
+        let weight = weight ?? .regular
+        let dogpatch = Dogpatch.with(weight: weight, design: design)
+        guard let font = UIFont(name: dogpatch.rawValue, size: size) else {
+            fontLogger.error("Font not found: \(dogpatch.rawValue, privacy: .public)")
+            return UIFont.systemFont(ofSize: size, weight: weight.toUIFontWeight())
+        }
+        return font
+    }
+
     public static func dogpatch(_ style: Font.TextStyle, design: Dogpatch.Design? = nil, weight: Dogpatch.Weight? = nil) -> UIFont {
         let design = design ?? .sans
         let weight = weight ?? .regular
@@ -108,6 +119,17 @@ private extension Font.TextStyle {
         case .caption2:     .caption2
         case .footnote:     .footnote
         default:            .body
+        }
+    }
+}
+
+private extension Dogpatch.Weight {
+    func toUIFontWeight() -> UIFont.Weight {
+        switch self {
+        case .light:        .light
+        case .regular:      .regular
+        case .medium:       .medium
+        case .bold:         .bold
         }
     }
 }


### PR DESCRIPTION
Minor UI tweak, using `.largeTitle` for `largeTitleTextAttributes` is way too large (43pt). The next `Font.TextStyle` notch down is `.title` which is too small (25pt). Kind of annoying because `Appearance` uses `UIFont` instead of `Font` and we didn't build as much tooling for it. Added a new `UIFont` constructor so we can specify size directly to fix this.

|Before|After|
|---|---|
|<img width="400" alt="title_before" src="https://github.com/user-attachments/assets/0450eaab-b0bb-454c-94a5-29010824b62b" />|<img width="400" alt="title_after" src="https://github.com/user-attachments/assets/7cf24bf9-14a7-4b48-9d3a-6ac1468afbe4" />|
