### PR TITLE
Unit tests for block list

### DIFF
--- a/lib/Sources/Bluetooth/BluetoothError.swift
+++ b/lib/Sources/Bluetooth/BluetoothError.swift
@@ -1,9 +1,8 @@
 import Foundation
 
-public enum BluetoothError: Error, Sendable {
+public enum BluetoothError: Error, Equatable, Sendable {
     case blocklisted(UUID)
     case cancelled
-    case causedBy(any Error)
     case deviceNotConnected
     case noSuchDevice(UUID)
     case noSuchService(UUID)
@@ -25,8 +24,6 @@ extension BluetoothError: LocalizedError {
             "UUID \(uuid) is on the block list"
         case .cancelled:
             "The operation was cancelled"
-        case let .causedBy(error):
-            error.localizedDescription
         case .deviceNotConnected:
             "Device is not connected"
         case let .noSuchDevice(uuid):

--- a/lib/Sources/Bluetooth/Fakes.swift
+++ b/lib/Sources/Bluetooth/Fakes.swift
@@ -83,4 +83,15 @@ public func FakeCharacteristic(
     )
 }
 
+public func FakeDescriptor(
+    uuid: UUID,
+    value: Descriptor.Value = .none
+) -> Descriptor {
+    Descriptor(
+        descriptor: AnyProtectedObject(wrapping: NSObject(), in: NonLockingStrategy()),
+        uuid: uuid,
+        value: value
+    )
+}
+
 #endif

--- a/lib/Sources/BluetoothAction/DiscoverCharacteristics.swift
+++ b/lib/Sources/BluetoothAction/DiscoverCharacteristics.swift
@@ -75,11 +75,13 @@ struct DiscoverCharacteristics: BluetoothAction {
         await state.setCharacteristics(result.characteristics, on: peripheral.id, serviceId: result.serviceId)
         switch request.query {
         case let .first(characteristicUuid):
+            // Already filtered, return the first one:
             guard let characteristic = result.characteristics.first else {
                 throw BluetoothError.noSuchCharacteristic(service: request.serviceUuid, characteristic: characteristicUuid)
             }
             return DiscoverCharacteristicsResponse(characteristics: [characteristic])
         case .all:
+            // Already filtered, return all of them:
             return DiscoverCharacteristicsResponse(characteristics: result.characteristics)
         }
     }

--- a/lib/Sources/BluetoothAction/DiscoverServices.swift
+++ b/lib/Sources/BluetoothAction/DiscoverServices.swift
@@ -50,7 +50,6 @@ struct DiscoverServicesRequest: JsMessageDecodable {
 }
 
 struct DiscoverServicesResponse: JsMessageEncodable {
-    let peripheralId: UUID
     let services: [Service]
 
     func toJsMessage() -> JsMessage.JsMessageResponse {
@@ -73,12 +72,14 @@ struct DiscoverServices: BluetoothAction {
         let primaryServices = result.services.filter { $0.isPrimary }
         switch request.query {
         case let .first(serviceUuid):
+            // Already filtered, return the first one:
             guard let service = primaryServices.first else {
                 throw BluetoothError.noSuchService(serviceUuid)
             }
-            return DiscoverServicesResponse(peripheralId: peripheral.id, services: [service])
+            return DiscoverServicesResponse(services: [service])
         case .all:
-            return DiscoverServicesResponse(peripheralId: peripheral.id, services: primaryServices)
+            // Already filtered, return all of them:
+            return DiscoverServicesResponse(services: primaryServices)
         }
     }
 

--- a/lib/Sources/BluetoothClient/BluetoothClientError.swift
+++ b/lib/Sources/BluetoothClient/BluetoothClientError.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+public enum BluetoothClientError: Error, Sendable {
+    case causedBy(any Error)
+}
+
+extension BluetoothClientError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case let .causedBy(error):
+            error.localizedDescription
+        }
+    }
+}

--- a/lib/Sources/BluetoothEngine/Errors.swift
+++ b/lib/Sources/BluetoothEngine/Errors.swift
@@ -7,7 +7,6 @@ extension BluetoothError: DomErrorConvertable {
         switch self {
         case .blocklisted: .security
         case .cancelled: .abort
-        case .causedBy: .operation
         case .deviceNotConnected: .network
         case .noSuchDevice: .notFound
         case .noSuchService: .notFound
@@ -20,6 +19,14 @@ extension BluetoothError: DomErrorConvertable {
         case .unauthorized: .notAllowed
         case .unavailable: .operation
         case .unknown: .unknown
+        }
+    }
+}
+
+extension BluetoothClientError: DomErrorConvertable {
+    public var domErrorName: DomErrorName {
+        switch self {
+        case .causedBy: .operation
         }
     }
 }

--- a/lib/Sources/JsMessage/DomError.swift
+++ b/lib/Sources/JsMessage/DomError.swift
@@ -4,7 +4,7 @@ import OSLog
 private let log = Logger(subsystem: "JsMessage", category: "DomError")
 
 /// Structured data representing a DOMException
-public struct DomError: Sendable, Encodable, Error {
+public struct DomError: Sendable, Encodable, Equatable, Error {
     public let name: DomErrorName
     public let msg: String?
 

--- a/lib/Sources/JsMessage/DomErrorName.swift
+++ b/lib/Sources/JsMessage/DomErrorName.swift
@@ -1,6 +1,6 @@
 
 /// https://webidl.spec.whatwg.org/#idl-DOMException-error-names
-public enum DomErrorName: String, Sendable, Encodable {
+public enum DomErrorName: String, Sendable, Equatable, Encodable {
     case abort = "AbortError"
     case encoding = "EncodingError"
     case invalidState = "InvalidStateError"

--- a/lib/Tests/BluetoothActionTests/DiscoverDescriptorsTests.swift
+++ b/lib/Tests/BluetoothActionTests/DiscoverDescriptorsTests.swift
@@ -1,0 +1,257 @@
+import Bluetooth
+@testable import BluetoothAction
+import BluetoothClient
+import BluetoothMessage
+import Foundation
+import JsMessage
+import SecurityList
+import TestHelpers
+import Testing
+
+extension Tag {
+    @Tag static var discoverDescriptors: Self
+}
+
+@Suite(.tags(.discoverDescriptors))
+struct DiscoverDescriptorsRequestTests {
+    @Test
+    func decode_withSingleDescriptor_succeeds() {
+        let deviceUuid = UUID(n: 0)
+        let serviceUuid = UUID(n: 1)
+        let characteristicUuid = UUID(n: 2)
+        let instance: NSNumber = 2
+        let descriptorUuid = UUID(n: 3)
+        let body: [String: JsType] = [
+            "single": .number(true),
+            "device": .string(deviceUuid.uuidString),
+            "service": .string(serviceUuid.uuidString),
+            "characteristic": .string(characteristicUuid.uuidString),
+            "instance": .number(instance),
+            "descriptor": .string(descriptorUuid.uuidString),
+        ]
+        let request = DiscoverDescriptorsRequest.decode(from: body)
+        #expect(request?.peripheralId == deviceUuid)
+        #expect(request?.serviceUuid == serviceUuid)
+        #expect(request?.characteristicUuid == characteristicUuid)
+        #expect(request?.instance == instance.uint32Value)
+        #expect(request?.query.descriptorUuid == descriptorUuid)
+    }
+
+    @Test
+    func decode_withoutDescriptor_succeeds() {
+        let deviceUuid = UUID(n: 0)
+        let serviceUuid = UUID(n: 1)
+        let characteristicUuid = UUID(n: 2)
+        let instance: NSNumber = 2
+        let body: [String: JsType] = [
+            "single": .number(false),
+            "device": .string(deviceUuid.uuidString),
+            "service": .string(serviceUuid.uuidString),
+            "characteristic": .string(characteristicUuid.uuidString),
+            "instance": .number(instance),
+        ]
+        let request = DiscoverDescriptorsRequest.decode(from: body)
+        #expect(request?.peripheralId == deviceUuid)
+        #expect(request?.serviceUuid == serviceUuid)
+        #expect(request?.characteristicUuid == characteristicUuid)
+        #expect(request?.instance == instance.uint32Value)
+        #expect(request?.query.descriptorUuid == nil)
+    }
+
+    @Test
+    func decode_withNonSingleDescriptor_succeeds() {
+        let deviceUuid = UUID(n: 0)
+        let serviceUuid = UUID(n: 1)
+        let characteristicUuid = UUID(n: 2)
+        let instance: NSNumber = 2
+        let descriptorUuid = UUID(n: 3)
+        let body: [String: JsType] = [
+            "single": .number(false),
+            "device": .string(deviceUuid.uuidString),
+            "service": .string(serviceUuid.uuidString),
+            "characteristic": .string(characteristicUuid.uuidString),
+            "instance": .number(instance),
+            "descriptor": .string(descriptorUuid.uuidString),
+        ]
+        let request = DiscoverDescriptorsRequest.decode(from: body)
+        #expect(request?.peripheralId == deviceUuid)
+        #expect(request?.serviceUuid == serviceUuid)
+        #expect(request?.characteristicUuid == characteristicUuid)
+        #expect(request?.instance == instance.uint32Value)
+        #expect(request?.query.descriptorUuid == descriptorUuid)
+    }
+}
+
+@Suite(.tags(.discoverDescriptors))
+struct DiscoverDescriptorsResponseTests {
+    @Test
+    func toJsMessage_withSingleDescriptor_hasExpectedBody() throws {
+        let fake = FakeDescriptor(uuid: UUID(n: 1), value: .none)
+        let sut = DiscoverDescriptorsResponse(descriptors: [fake])
+        let jsMessage = sut.toJsMessage()
+        let body = try #require(jsMessage.extractBody(as: NSArray.self))
+        let expectedBody: NSArray = [
+            fake.uuid.uuidString.lowercased(),
+        ]
+        #expect(body.count == 1)
+        #expect(body == expectedBody)
+    }
+
+    @Test
+    func toJsMessage_withMultipleDescriptors_hasExpectedBody() throws {
+        let fakeDescriptors = [
+            FakeDescriptor(uuid: UUID(n: 1), value: .none),
+            FakeDescriptor(uuid: UUID(uuidString: "00000000-0000-0000-0000-00000BA7F00D")!, value: .none)
+        ]
+        let sut = DiscoverDescriptorsResponse(descriptors: fakeDescriptors)
+        let jsMessage = sut.toJsMessage()
+        let body = try #require(jsMessage.extractBody(as: NSArray.self))
+        let expectedBody = fakeDescriptors.map { descriptor in
+            descriptor.uuid.uuidString.lowercased()
+        } as NSArray
+        #expect(body.count == 2)
+        #expect(body == expectedBody)
+    }
+}
+
+@Suite(.tags(.discoverDescriptors))
+struct DiscoverDescriptorsTests {
+    @Test
+    func execute_withRequestForSingleDescriptor_respondsWithSingleDescriptor() async throws {
+        let fakeDescriptors = [
+            FakeDescriptor(uuid: UUID(n: 40)),
+            FakeDescriptor(uuid: UUID(n: 41)),
+        ]
+        let matchingDescriptor = fakeDescriptors[1]
+        let fakeCharacteristic = FakeCharacteristic(uuid: UUID(n: 31))
+        let fakeService = FakeService(uuid: UUID(n: 30), characteristics: [fakeCharacteristic])
+        let fake = FakePeripheral(id: UUID(n: 0), connectionState: .connected, services: [fakeService])
+        let client = clientThatSucceeds(with: fakeDescriptors)
+        let state = BluetoothState(peripherals: [fake])
+        let request = DiscoverDescriptorsRequest(
+            peripheralId: fake.id,
+            serviceUuid: fakeService.uuid,
+            characteristicUuid: fakeCharacteristic.uuid,
+            instance: fakeCharacteristic.instance,
+            query: .first(matchingDescriptor.uuid)
+        )
+        let sut = DiscoverDescriptors(request: request)
+        let response = try await sut.execute(state: state, client: client)
+        #expect(response.descriptors == [matchingDescriptor])
+    }
+
+    @Test
+    func execute_withRequestForUnspecifiedDescriptor_respondsWithAllDescriptors() async throws {
+        let fakeDescriptors = [
+            FakeDescriptor(uuid: UUID(n: 40)),
+            FakeDescriptor(uuid: UUID(n: 41)),
+        ]
+        let fakeCharacteristic = FakeCharacteristic(uuid: UUID(n: 31))
+        let fakeService = FakeService(uuid: UUID(n: 30), characteristics: [fakeCharacteristic])
+        let fake = FakePeripheral(id: UUID(n: 0), connectionState: .connected, services: [fakeService])
+        let client = clientThatSucceeds(with: fakeDescriptors)
+        let state = BluetoothState(peripherals: [fake])
+        let request = DiscoverDescriptorsRequest(
+            peripheralId: fake.id,
+            serviceUuid: fakeService.uuid,
+            characteristicUuid: fakeCharacteristic.uuid,
+            instance: fakeCharacteristic.instance,
+            query: .all(nil)
+        )
+        let sut = DiscoverDescriptors(request: request)
+        let response = try await sut.execute(state: state, client: client)
+        #expect(response.descriptors == fakeDescriptors)
+    }
+
+    @Test
+    func execute_withRequestForNonSingleDescriptor_respondsWithMatchingDescriptor() async throws {
+        let fakeDescriptors = [
+            FakeDescriptor(uuid: UUID(n: 40)),
+            FakeDescriptor(uuid: UUID(n: 41)),
+        ]
+        let matchingDescriptor = fakeDescriptors[1]
+        let fakeCharacteristic = FakeCharacteristic(uuid: UUID(n: 31))
+        let fakeService = FakeService(uuid: UUID(n: 30), characteristics: [fakeCharacteristic])
+        let fake = FakePeripheral(id: UUID(n: 0), connectionState: .connected, services: [fakeService])
+        let client = clientThatSucceeds(with: fakeDescriptors)
+        let state = BluetoothState(peripherals: [fake])
+        let request = DiscoverDescriptorsRequest(
+            peripheralId: fake.id,
+            serviceUuid: fakeService.uuid,
+            characteristicUuid: fakeCharacteristic.uuid,
+            instance: fakeCharacteristic.instance,
+            query: .all(matchingDescriptor.uuid)
+        )
+        let sut = DiscoverDescriptors(request: request)
+        let response = try await sut.execute(state: state, client: client)
+        #expect(response.descriptors == [matchingDescriptor])
+    }
+
+    @Test
+    func execute_withBlockedDescriptorUuid_throwsBlocklistedError() async throws {
+        let descriptorUuid = UUID(n: 40)
+        let securityList = SecurityList(descriptors: [descriptorUuid: .any])
+        let state = BluetoothState(securityList: securityList)
+        let request = DiscoverDescriptorsRequest(
+            peripheralId: UUID(n: 0),
+            serviceUuid: UUID(n: 10),
+            characteristicUuid: UUID(n: 30),
+            instance: 0,
+            query: .first(descriptorUuid)
+        )
+        let sut = DiscoverDescriptors(request: request)
+        await #expect(throws: BluetoothError.blocklisted(descriptorUuid)) {
+            _ = try await sut.execute(state: state, client: MockBluetoothClient())
+        }
+    }
+
+    @Test
+    func execute_withBlockedServiceUuid_throwsBlocklistedError() async throws {
+        let serviceUuid = UUID(n: 10)
+        let securityList = SecurityList(services: [serviceUuid: .any])
+        let state = BluetoothState(securityList: securityList)
+        let request = DiscoverDescriptorsRequest(
+            peripheralId: UUID(n: 0),
+            serviceUuid: serviceUuid,
+            characteristicUuid: UUID(n: 30),
+            instance: 0,
+            query: .all(nil)
+        )
+        let sut = DiscoverDescriptors(request: request)
+        await #expect(throws: BluetoothError.blocklisted(serviceUuid)) {
+            _ = try await sut.execute(state: state, client: MockBluetoothClient())
+        }
+    }
+
+    @Test
+    func execute_withBlockedCharacteristicUuid_throwsBlocklistedError() async throws {
+        let characteristicUuid = UUID(n: 30)
+        let securityList = SecurityList(characteristics: [characteristicUuid: .any])
+        let state = BluetoothState(securityList: securityList)
+        let request = DiscoverDescriptorsRequest(
+            peripheralId: UUID(n: 0),
+            serviceUuid: UUID(n: 10),
+            characteristicUuid: characteristicUuid,
+            instance: 0,
+            query: .all(nil)
+        )
+        let sut = DiscoverDescriptors(request: request)
+        await #expect(throws: BluetoothError.blocklisted(characteristicUuid)) {
+            _ = try await sut.execute(state: state, client: MockBluetoothClient())
+        }
+    }
+
+    private func clientThatSucceeds(with descriptors: [Descriptor]) -> BluetoothClient {
+        var client = MockBluetoothClient()
+        client.onDiscoverDescriptors = { peripheral, characteristic in
+            DescriptorDiscoveryEvent(
+                peripheralId: peripheral.id,
+                serviceId: peripheral.services[0].uuid,
+                characteristicId: peripheral.services[0].characteristics[0].uuid,
+                instance: peripheral.services[0].characteristics[0].instance,
+                descriptors: descriptors
+            )
+        }
+        return client
+    }
+}

--- a/lib/Tests/BluetoothActionTests/DiscoverDescriptorsTests.swift
+++ b/lib/Tests/BluetoothActionTests/DiscoverDescriptorsTests.swift
@@ -101,7 +101,7 @@ struct DiscoverDescriptorsResponseTests {
     func toJsMessage_withMultipleDescriptors_hasExpectedBody() throws {
         let fakeDescriptors = [
             FakeDescriptor(uuid: UUID(n: 1), value: .none),
-            FakeDescriptor(uuid: UUID(uuidString: "00000000-0000-0000-0000-00000BA7F00D")!, value: .none)
+            FakeDescriptor(uuid: UUID(uuidString: "00000000-0000-0000-0000-00000BA7F00D")!, value: .none),
         ]
         let sut = DiscoverDescriptorsResponse(descriptors: fakeDescriptors)
         let jsMessage = sut.toJsMessage()
@@ -247,8 +247,8 @@ struct DiscoverDescriptorsTests {
             DescriptorDiscoveryEvent(
                 peripheralId: peripheral.id,
                 serviceId: peripheral.services[0].uuid,
-                characteristicId: peripheral.services[0].characteristics[0].uuid,
-                instance: peripheral.services[0].characteristics[0].instance,
+                characteristicId: characteristic.uuid,
+                instance: characteristic.instance,
                 descriptors: descriptors
             )
         }

--- a/lib/Tests/BluetoothActionTests/DiscoverServicesTests.swift
+++ b/lib/Tests/BluetoothActionTests/DiscoverServicesTests.swift
@@ -1,0 +1,163 @@
+import Bluetooth
+@testable import BluetoothAction
+import BluetoothClient
+import BluetoothMessage
+import Foundation
+import JsMessage
+import SecurityList
+import TestHelpers
+import Testing
+
+extension Tag {
+    @Tag static var discoverServices: Self
+}
+
+@Suite(.tags(.discoverServices))
+struct DiscoverServicesRequestTests {
+    @Test
+    func decode_withSingleService_succeeds() {
+        let deviceUuid = UUID(n: 0)
+        let serviceUuid = UUID(n: 1)
+        let body: [String: JsType] = [
+            "single": .number(true),
+            "device": .string(deviceUuid.uuidString),
+            "service": .string(serviceUuid.uuidString),
+        ]
+        let request = DiscoverServicesRequest.decode(from: body)
+        #expect(request?.peripheralId == deviceUuid)
+        #expect(request?.query.serviceUuid == serviceUuid)
+    }
+
+    @Test
+    func decode_withoutService_succeeds() {
+        let deviceUuid = UUID(n: 0)
+        let body: [String: JsType] = [
+            "single": .number(false),
+            "device": .string(deviceUuid.uuidString),
+        ]
+        let request = DiscoverServicesRequest.decode(from: body)
+        #expect(request?.peripheralId == deviceUuid)
+        #expect(request?.query.serviceUuid == nil)
+    }
+
+    @Test
+    func decode_withNonSingleDescriptor_succeeds() {
+        let deviceUuid = UUID(n: 0)
+        let serviceUuid = UUID(n: 1)
+        let body: [String: JsType] = [
+            "single": .number(false),
+            "device": .string(deviceUuid.uuidString),
+            "service": .string(serviceUuid.uuidString),
+        ]
+        let request = DiscoverServicesRequest.decode(from: body)
+        #expect(request?.peripheralId == deviceUuid)
+        #expect(request?.query.serviceUuid == serviceUuid)
+    }
+}
+
+@Suite(.tags(.discoverServices))
+struct DiscoverServicesResponseTests {
+    @Test
+    func toJsMessage_withSingleDescriptor_hasExpectedBody() throws {
+        let fake = FakeService(uuid: UUID(n: 10))
+        let sut = DiscoverServicesResponse(services: [fake])
+        let jsMessage = sut.toJsMessage()
+        let body = try #require(jsMessage.extractBody(as: NSDictionary.self))
+        let bodyServicesArray = try #require(body["services"]! as? NSArray)
+        let expectedUuidArray: NSArray = [
+            fake.uuid.uuidString.lowercased(),
+        ]
+        #expect(bodyServicesArray.count == 1)
+        #expect(bodyServicesArray == expectedUuidArray)
+    }
+
+    @Test
+    func toJsMessage_withMultipleDescriptors_hasExpectedBody() throws {
+        let fakeServices = [
+            FakeService(uuid: UUID(n: 1)),
+            FakeService(uuid: UUID(uuidString: "00000000-0000-0000-0000-00000BA7F00D")!)
+        ]
+        let sut = DiscoverServicesResponse(services: fakeServices)
+        let jsMessage = sut.toJsMessage()
+        let body = try #require(jsMessage.extractBody(as: NSDictionary.self))
+        let bodyServicesArray = try #require(body["services"]! as? NSArray)
+        let expectedUuidArray = fakeServices.map { service in
+            service.uuid.uuidString.lowercased()
+        } as NSArray
+        #expect(bodyServicesArray.count == 2)
+        #expect(bodyServicesArray == expectedUuidArray)
+    }
+}
+
+@Suite(.tags(.discoverServices))
+struct DiscoverServicesTests {
+    @Test
+    func execute_withRequestForSingleService_respondsWithSingleService() async throws {
+        let fakeServices = [
+            FakeService(uuid: UUID(n: 10)),
+            FakeService(uuid: UUID(n: 11)),
+        ]
+        let matchingService = fakeServices[1]
+        let fake = FakePeripheral(id: UUID(n: 0), connectionState: .connected, services: fakeServices)
+        var client = MockBluetoothClient()
+        client.onDiscoverServices = { peripheral, filter in
+            #expect(filter.services == [matchingService.uuid])
+            return ServiceDiscoveryEvent(peripheralId: peripheral.id, services: [matchingService])
+        }
+        let state = BluetoothState(peripherals: [fake])
+        let request = DiscoverServicesRequest(peripheralId: fake.id, query: .first(matchingService.uuid))
+        let sut = DiscoverServices(request: request)
+        let response = try await sut.execute(state: state, client: client)
+        #expect(response.services == [matchingService])
+    }
+
+    @Test
+    func execute_withRequestForUnspecifiedservice_respondsWithAllServices() async throws {
+        let fakeServices = [
+            FakeService(uuid: UUID(n: 10)),
+            FakeService(uuid: UUID(n: 11)),
+        ]
+        let matchingService = fakeServices[1]
+        let fake = FakePeripheral(id: UUID(n: 0), connectionState: .connected, services: fakeServices)
+        var client = MockBluetoothClient()
+        client.onDiscoverServices = { peripheral, filter in
+            #expect(filter.services == nil)
+            return ServiceDiscoveryEvent(peripheralId: peripheral.id, services: fakeServices)
+        }
+        let state = BluetoothState(peripherals: [fake])
+        let request = DiscoverServicesRequest(peripheralId: fake.id, query: .all(nil))
+        let sut = DiscoverServices(request: request)
+        let response = try await sut.execute(state: state, client: client)
+        #expect(response.services == fakeServices)
+    }
+
+    @Test
+    func execute_withRequestForBlockedServiceUuid_throwsBlocklistedError() async throws {
+        let serviceUuid = UUID(n: 10)
+        let securityList = SecurityList(services: [serviceUuid: .any])
+        let state = BluetoothState(securityList: securityList)
+        let request = DiscoverServicesRequest(peripheralId: UUID(n: 0), query: .first(serviceUuid))
+        let sut = DiscoverServices(request: request)
+        await #expect(throws: BluetoothError.blocklisted(serviceUuid)) {
+            _ = try await sut.execute(state: state, client: MockBluetoothClient())
+        }
+    }
+
+    @Test(.disabled("Requires https://github.com/JuulLabs/topaz/issues/119"))
+    func execute_withRequestForAllServices_respondsWithBlockedServicesRemoved() async throws {
+        let allowedService = FakeService(uuid: UUID(n: 10))
+        let blockedService = FakeService(uuid: UUID(n: 11))
+        let fakeServices = [allowedService, blockedService]
+        let fake = FakePeripheral(id: UUID(n: 0), connectionState: .connected, services: fakeServices)
+        var client = MockBluetoothClient()
+        client.onDiscoverServices = { peripheral, filter in
+            return ServiceDiscoveryEvent(peripheralId: peripheral.id, services: fakeServices)
+        }
+        let securityList = SecurityList(services: [blockedService.uuid: .any])
+        let state = BluetoothState(peripherals: [fake], securityList: securityList)
+        let request = DiscoverServicesRequest(peripheralId: UUID(n: 0), query: .all(nil))
+        let sut = DiscoverServices(request: request)
+        let response = try await sut.execute(state: state, client: client)
+        #expect(response.services == [allowedService])
+    }
+}

--- a/lib/Tests/BluetoothActionTests/DiscoverServicesTests.swift
+++ b/lib/Tests/BluetoothActionTests/DiscoverServicesTests.swift
@@ -75,7 +75,7 @@ struct DiscoverServicesResponseTests {
     func toJsMessage_withMultipleDescriptors_hasExpectedBody() throws {
         let fakeServices = [
             FakeService(uuid: UUID(n: 1)),
-            FakeService(uuid: UUID(uuidString: "00000000-0000-0000-0000-00000BA7F00D")!)
+            FakeService(uuid: UUID(uuidString: "00000000-0000-0000-0000-00000BA7F00D")!),
         ]
         let sut = DiscoverServicesResponse(services: fakeServices)
         let jsMessage = sut.toJsMessage()
@@ -117,7 +117,6 @@ struct DiscoverServicesTests {
             FakeService(uuid: UUID(n: 10)),
             FakeService(uuid: UUID(n: 11)),
         ]
-        let matchingService = fakeServices[1]
         let fake = FakePeripheral(id: UUID(n: 0), connectionState: .connected, services: fakeServices)
         var client = MockBluetoothClient()
         client.onDiscoverServices = { peripheral, filter in
@@ -150,7 +149,7 @@ struct DiscoverServicesTests {
         let fakeServices = [allowedService, blockedService]
         let fake = FakePeripheral(id: UUID(n: 0), connectionState: .connected, services: fakeServices)
         var client = MockBluetoothClient()
-        client.onDiscoverServices = { peripheral, filter in
+        client.onDiscoverServices = { peripheral, _ in
             return ServiceDiscoveryEvent(peripheralId: peripheral.id, services: fakeServices)
         }
         let securityList = SecurityList(services: [blockedService.uuid: .any])

--- a/lib/Tests/BluetoothActionTests/StopNotificationsTests.swift
+++ b/lib/Tests/BluetoothActionTests/StopNotificationsTests.swift
@@ -63,13 +63,8 @@ struct StopNotificationsTests {
         let request = CharacteristicRequest(peripheralId: fakePeripheralId, serviceUuid: fakeServiceUuid, characteristicUuid: nonExistentCharacteristicUuid, characteristicInstance: fakeCharacteristicInstance)
         let sut = StopNotifications(request: request)
 
-        await #expect {
+        await #expect(throws: BluetoothError.noSuchCharacteristic(service: fakeServiceUuid, characteristic: nonExistentCharacteristicUuid)) {
             _ = try await sut.execute(state: state, client: mockBluetoothClient())
-        } throws: { (error: any Error) in
-            guard case .noSuchCharacteristic(service: fakeServiceUuid, characteristic: nonExistentCharacteristicUuid) = (error as? BluetoothError) else {
-                return false
-            }
-            return true
         }
     }
 }


### PR DESCRIPTION
_Follow up from #156_

Adds unit tests for the block list conditions in the actions. Also added full unit tests for discover services and discover descriptors as they didn't have any at all.

To make testing more ergonomic we need `BluetoothError` to be `Equatable`, so moved the `causedBy(any Error)` case to its own structure as it prevents automatic `Equatable` conformance. It is used only by `BluetoothClient` so is nicely isolated anyway. This helps cleans up some of the existing tests as well.

Note: writing the tests for `DiscoverDescriptors` revealed that the implementation was not quite doing what was expected, in that it was always returning all descriptors. It now filters the descriptors if the request specifies such. This part of the spec is pretty hard to follow so I hope I have that right, please consider that carefully to ensure I haven't mis-understood this bit.