### PR TITLE
Lowercased UUID unit tests

### DIFF
--- a/lib/Sources/BluetoothAction/Disconnect.swift
+++ b/lib/Sources/BluetoothAction/Disconnect.swift
@@ -17,7 +17,6 @@ struct DisconnectRequest: JsMessageDecodable {
 }
 
 struct DisconnectResponse: JsMessageEncodable {
-    let peripheralId: UUID
     let isDisconnected: Bool = true
 
     func toJsMessage() -> JsMessage.JsMessageResponse {
@@ -32,12 +31,12 @@ struct Disconnector: BluetoothAction {
     func execute(state: BluetoothState, client: BluetoothClient, eventBus: EventBus) async throws -> DisconnectResponse {
         let peripheral = try await state.getPeripheral(request.peripheralId)
         if case .disconnected = peripheral.connectionState {
-            return DisconnectResponse(peripheralId: peripheral.id)
+            return DisconnectResponse()
         }
         let _: DisconnectionEvent = try await eventBus.awaitEvent(forKey: .peripheral(.disconnect, peripheral)) {
             client.disconnect(peripheral: peripheral)
         }
-        return DisconnectResponse(peripheralId: peripheral.id)
+        return DisconnectResponse()
     }
 }
 

--- a/lib/Sources/TestHelpers/UUID.swift
+++ b/lib/Sources/TestHelpers/UUID.swift
@@ -3,10 +3,11 @@ import Foundation
 extension UUID {
     /// Create a UUID with an unsigned decimal representaiton of n in the last quartet
     /// Large values of n are clamped at 2^32 == 4,294,967,295
+    /// Some hex digits are included in the higher bytes to exercise case-sensitiviy requirements
     public init(n: Int) {
         let numStr = UInt32(clamping: n).description
         let padCount = max(0, 12 - numStr.count)
         let prefix = String(repeating: "0", count: padCount)
-        self.init(uuidString: "00000000-0000-0000-0000-" + prefix + numStr)!
+        self.init(uuidString: "00000000-0000-BEEF-cafe-" + prefix + numStr)!
     }
 }

--- a/lib/Tests/BluetoothActionTests/DisconnectTests.swift
+++ b/lib/Tests/BluetoothActionTests/DisconnectTests.swift
@@ -1,0 +1,161 @@
+import Bluetooth
+@testable import BluetoothAction
+import BluetoothClient
+import BluetoothMessage
+import EventBus
+import Foundation
+import JsMessage
+import TestHelpers
+import Testing
+
+extension Tag {
+    @Tag static var disconnect: Self
+}
+
+@Suite(.tags(.disconnect))
+struct DisonnectRequestTests {
+    @Test
+    func decode_withValidUuid_succeeds() {
+        let uuid = UUID(n: 0)
+        let body: [String: JsType] = [
+            "uuid": .string(uuid.uuidString),
+        ]
+        let request = DisconnectRequest.decode(from: body)
+        #expect(request?.peripheralId == uuid)
+    }
+
+    @Test
+    func decode_withExtraBodyData_succeedsAndIgnoresExtras() {
+        let uuid = UUID(n: 0)
+        let body: [String: JsType] = [
+            "uuid": .string(uuid.uuidString),
+            "bananaCount": .number(42),
+        ]
+        let request = DisconnectRequest.decode(from: body)
+        #expect(request?.peripheralId == uuid)
+    }
+
+    @Test
+    func decode_withInvalidUuid_isNil() {
+        let body: [String: JsType] = [
+            "uuid": .string("bananaman"),
+        ]
+        let request = DisconnectRequest.decode(from: body)
+        #expect(request == nil)
+    }
+
+    @Test
+    func decode_withEmptyBody_isNil() {
+        let body: [String: JsType] = [:]
+        let request = DisconnectRequest.decode(from: body)
+        #expect(request == nil)
+    }
+}
+
+@Suite(.tags(.disconnect))
+struct DisonnectResponseTests {
+    @Test
+    func toJsMessage_withDefaultResponse_hasExpectedBody() throws {
+        let sut = DisconnectResponse()
+        let jsMessage = sut.toJsMessage()
+        let body = try #require(jsMessage.extractBody(as: NSDictionary.self))
+        #expect(body == ["disconnected": true])
+    }
+}
+
+@Suite(.tags(.disconnect))
+struct DisconnectorTests {
+    private let zeroUuid: UUID = UUID(n: 0)
+
+    @Test
+    func execute_withAlreadyDisconnectedPeripheral_respondsWithIsDisconnectedTrue() async throws {
+        let state = BluetoothState(peripherals: [FakePeripheral(id: zeroUuid, connectionState: .disconnected)])
+        let request = DisconnectRequest(peripheralId: zeroUuid)
+        let sut = Disconnector(request: request)
+        let response = try await sut.execute(state: state, client: MockBluetoothClient(), eventBus: EventBus())
+        #expect(response.isDisconnected == true)
+    }
+
+    @Test
+    func execute_withRequestedDisconnection_respondsWithIsDisconnectedTrue() async throws {
+        let state = BluetoothState(peripherals: [FakePeripheral(id: zeroUuid, connectionState: .connected)])
+        let request = DisconnectRequest(peripheralId: zeroUuid)
+        let eventBus = await selfResolvingEventBus()
+        var client = MockBluetoothClient()
+        client.onDisconnect = { _ in
+            let disconnectedDevice = FakePeripheral(id: zeroUuid, connectionState: .disconnected)
+            eventBus.enqueueEvent(DisconnectionEvent.requested(disconnectedDevice))
+        }
+        let sut = Disconnector(request: request)
+        let response = try await sut.execute(state: state, client: client, eventBus: eventBus)
+        #expect(response.isDisconnected == true)
+    }
+
+    @Test
+    func execute_withUnexpectedDisconnection_respondsWithIsDisconnectedTrue() async throws {
+        let state = BluetoothState(peripherals: [FakePeripheral(id: zeroUuid, connectionState: .connected)])
+        let request = DisconnectRequest(peripheralId: zeroUuid)
+        let eventBus = await selfResolvingEventBus()
+        var client = MockBluetoothClient()
+        client.onDisconnect = { _ in
+            let disconnectedDevice = FakePeripheral(id: zeroUuid, connectionState: .disconnected)
+            eventBus.enqueueEvent(DisconnectionEvent.unexpected(disconnectedDevice, TestError()))
+        }
+        let sut = Disconnector(request: request)
+        let response = try await sut.execute(state: state, client: client, eventBus: eventBus)
+        #expect(response.isDisconnected == true)
+    }
+}
+
+@Suite(.tags(.disconnect))
+struct DisconnectionEventTests {
+    @Test
+    func gattServerDisconnectedEvent_requestedDisconnectAsJsValue_hasExpectedBody() throws {
+        let deviceUuid = UUID(n: 0)
+        let disconnectedDevice = FakePeripheral(id: deviceUuid, connectionState: .disconnected)
+        let sut = DisconnectionEvent.requested(disconnectedDevice)
+        let jsEvent = sut.gattServerDisconnectedEvent()
+
+        // Convert the event to the Js representation
+        let encoded = jsEvent.jsValue
+        // Convert it back to the native representation so we can check the values
+        let decoded = try #require(JsType.bridge(encoded).dictionary)
+        let decodedBody = try #require(decoded["data"]?.dictionary)
+
+        // Event properties
+        #expect(decoded["id"]?.string == deviceUuid.uuidString.lowercased())
+        #expect(decoded["name"]?.string == "gattserverdisconnected")
+
+        // Event data properties
+        #expect(decodedBody["reason"]?.string == "disconnected")
+    }
+
+    @Test
+    func gattServerDisconnectedEvent_unexpectedDisconnectAsJsValue_hasExpectedBody() throws {
+        let deviceUuid = UUID(n: 0)
+        let disconnectedDevice = FakePeripheral(id: deviceUuid, connectionState: .disconnected)
+        let sut = DisconnectionEvent.unexpected(disconnectedDevice, TestError())
+        let jsEvent = sut.gattServerDisconnectedEvent()
+
+        // Convert the event to the Js representation
+        let encoded = jsEvent.jsValue
+        // Convert it back to the native representation so we can check the values
+        let decoded = try #require(JsType.bridge(encoded).dictionary)
+        let decodedBody = try #require(decoded["data"]?.dictionary)
+
+        // Event properties
+        #expect(decoded["id"]?.string == deviceUuid.uuidString.lowercased())
+        #expect(decoded["name"]?.string == "gattserverdisconnected")
+
+        // Event data properties
+        #expect(decodedBody["reason"]?.string == "Test error reason")
+    }
+}
+
+private struct TestError: Error { }
+
+extension TestError: LocalizedError {
+    var errorDescription: String? {
+        "Test error reason"
+    }
+}

--- a/lib/Tests/BluetoothActionTests/DiscoverCharacteristicsTests.swift
+++ b/lib/Tests/BluetoothActionTests/DiscoverCharacteristicsTests.swift
@@ -76,7 +76,7 @@ struct DiscoverCharacteristicsResponseTests {
         let bodyCharacteristicsArray = try #require(body["characteristics"]! as? NSArray)
         let characteristicBody = try #require(bodyCharacteristicsArray[0] as? NSDictionary)
         let expectedCharacteristicBody: NSDictionary = [
-            "uuid": fake.uuid.uuidString,
+            "uuid": fake.uuid.uuidString.lowercased(),
             "instance": fake.instance,
             "properties": [
                 "authenticatedSignedWrites": false,

--- a/lib/Tests/BluetoothActionTests/GetDevicesTests.swift
+++ b/lib/Tests/BluetoothActionTests/GetDevicesTests.swift
@@ -29,7 +29,7 @@ struct GetDevicesResponseTests {
         let jsMessage = sut.toJsMessage()
         let body = try #require(jsMessage.extractBody(as: NSArray.self))
         let responseDict0 = [
-            "uuid": "00000000-0000-0000-0000-000000000000",
+            "uuid": "00000000-0000-beef-cafe-000000000000",
             "name": "Slartibartfast",
         ]
         #expect(body == [responseDict0])
@@ -46,11 +46,11 @@ struct GetDevicesResponseTests {
         let jsMessage = sut.toJsMessage()
         let body = try #require(jsMessage.extractBody(as: NSArray.self))
         let responseDict0 = [
-            "uuid": "00000000-0000-0000-0000-000000000000",
+            "uuid": "00000000-0000-beef-cafe-000000000000",
             "name": "Slarti",
         ]
         let responseDict1 = [
-            "uuid": "00000000-0000-0000-0000-000000000001",
+            "uuid": "00000000-0000-beef-cafe-000000000001",
             "name": "Bartfast",
         ]
         #expect(body == [responseDict0, responseDict1])


### PR DESCRIPTION
Audited all the actions to make sure all of the UUIDs emitted to Js are lowercased. Turns out there are no gaps there.

Updated and added a few more tests to get coverage of enforcment of lowercased UUIDs in all the responses.