### PR TITLE
Exclude blockisted UUIDs from discovery

### DIFF
--- a/lib/Sources/BluetoothAction/DiscoverDescriptors.swift
+++ b/lib/Sources/BluetoothAction/DiscoverDescriptors.swift
@@ -70,7 +70,8 @@ struct DiscoverDescriptors: BluetoothAction {
     let request: DiscoverDescriptorsRequest
 
     func execute(state: BluetoothState, client: BluetoothClient, eventBus: EventBus) async throws -> DiscoverDescriptorsResponse {
-        try await checkSecurityList(securityList: state.securityList)
+        let securityList = await state.securityList
+        try checkSecurityList(securityList: securityList)
         let peripheral = try await state.getConnectedPeripheral(request.peripheralId)
         let (_, characteristic) = try await state.getCharacteristic(
             peripheralId: request.peripheralId,
@@ -83,8 +84,11 @@ struct DiscoverDescriptors: BluetoothAction {
         ) {
             client.discoverDescriptors(peripheral: peripheral, characteristic: characteristic)
         }
+        let descriptors = result.descriptors.filter {
+            !securityList.isBlocked($0.uuid, in: .descriptors)
+        }
         await state.setDescriptors(
-            result.descriptors,
+            descriptors,
             on: peripheral.id,
             serviceId: result.serviceId,
             characteristicId: result.characteristicId,
@@ -93,20 +97,20 @@ struct DiscoverDescriptors: BluetoothAction {
         switch request.query {
         case let .first(descriptorUuid):
             // Result is not filtered, so do so now by taking the first match:
-            guard let descriptor = result.descriptors.first(where: { $0.uuid == descriptorUuid }) else {
+            guard let descriptor = descriptors.first(where: { $0.uuid == descriptorUuid }) else {
                 throw BluetoothError.noSuchDescriptor(characteristic: request.characteristicUuid, descriptor: descriptorUuid)
             }
             return DiscoverDescriptorsResponse(descriptors: [descriptor])
         case .all:
             // Result is not filtered, so do so now by taking all that match:
             if let descriptorUuid = request.query.descriptorUuid {
-                let descriptors = result.descriptors.filter { $0.uuid == descriptorUuid }
+                let descriptors = descriptors.filter { $0.uuid == descriptorUuid }
                 guard !descriptors.isEmpty else {
                     throw BluetoothError.noSuchDescriptor(characteristic: request.characteristicUuid, descriptor: descriptorUuid)
                 }
                 return DiscoverDescriptorsResponse(descriptors: descriptors)
             } else {
-                return DiscoverDescriptorsResponse(descriptors: result.descriptors)
+                return DiscoverDescriptorsResponse(descriptors: descriptors)
             }
         }
     }

--- a/lib/Tests/BluetoothActionTests/DiscoverServicesTests.swift
+++ b/lib/Tests/BluetoothActionTests/DiscoverServicesTests.swift
@@ -149,7 +149,7 @@ struct DiscoverServicesTests {
         }
     }
 
-    @Test(.disabled("Requires https://github.com/JuulLabs/topaz/issues/119"))
+    @Test
     func execute_withRequestForAllServices_respondsWithBlockedServicesRemoved() async throws {
         let eventBus = await selfResolvingEventBus()
         let allowedService = FakeService(uuid: UUID(n: 10))


### PR DESCRIPTION
We already check the block list for UUIDs that appear in any discovery query,  which prevents access to blocked attributes explicitly. This case throws an error for the user.

This change plugs the gap where the system may return blocked attributes when the user requests "all" of something without an explicit filter. When the native Bluetooth system returns results for discovered services, characteristics and descriptors, we strip out any that appear on the block list. This does not throw any error, the blocked items are silently removed to make them invisible to the user.
