### PR TITLE
Restrict permissions for services when using the device picker

### DIFF
--- a/lib/Sources/Bluetooth/BluetoothError.swift
+++ b/lib/Sources/Bluetooth/BluetoothError.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 public enum BluetoothError: Error, Equatable, Sendable {
+    case accessToServiceDenied(UUID)
     case blocklisted(UUID)
     case cancelled
     case deviceNotConnected
@@ -20,6 +21,8 @@ public enum BluetoothError: Error, Equatable, Sendable {
 extension BluetoothError: LocalizedError {
     public var errorDescription: String? {
         switch self {
+        case let .accessToServiceDenied(uuid):
+            "Access to service \(uuid.uuidString.lowercased()) denied. Tip: Add the service UUID to 'optionalServices' in requestDevice() options. https://goo.gl/HxfxSQ"
         case let .blocklisted(uuid):
             "UUID \(uuid) is on the block list"
         case .cancelled:

--- a/lib/Sources/Bluetooth/Peripheral.swift
+++ b/lib/Sources/Bluetooth/Peripheral.swift
@@ -6,17 +6,20 @@ public struct Peripheral: Sendable {
     public let id: UUID
     public let name: String?
     public var services: [Service]
+    public var permissions: PeripheralPermissions
 
     public init(
         peripheral: AnyProtectedObject,
         id: UUID,
         name: String? = nil,
-        services: [Service] = []
+        services: [Service] = [],
+        permissions: PeripheralPermissions = .init(allowedServices: .all)
     ) {
         self.id = id
         self.peripheral = peripheral
         self.name = name
         self.services = services
+        self.permissions = permissions
     }
 
     public var connectionState: ConnectionState? {

--- a/lib/Sources/Bluetooth/PeripheralPermissions.swift
+++ b/lib/Sources/Bluetooth/PeripheralPermissions.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/**
+ Manage access to peripheral services.
+
+ From [Mozilla Web API docs](https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth/requestDevice):
+
+ *After the user selects a device to pair in the current origin, it is only allowed to
+ access services whose UUID was listed in the services list in any element of filters.services
+ or in optionalServices.*
+ */
+public struct PeripheralPermissions: Sendable {
+    public enum AllowedUUIDs: Sendable {
+        case all
+        case restricted(Set<UUID>)
+    }
+
+    public let allowedServices: AllowedUUIDs
+
+    public init(allowedServices: AllowedUUIDs) {
+        self.allowedServices = allowedServices
+    }
+}

--- a/lib/Sources/BluetoothAction/Filter+Permissions.swift
+++ b/lib/Sources/BluetoothAction/Filter+Permissions.swift
@@ -25,9 +25,17 @@ import SecurityList
  * The inference here is that the blocklist is applied to optionalServices/optionalManufacturerData
  * by dint of the parser implementation. The intended effect is that advertisements and discovery
  * would silently strip out such elements later on due to the filter logic.
- *
- * TODO: apply the full filter logic to advertisements and discovery
  */
+
+extension Options {
+    /**
+     Create restricted permissions set to be applied when using the interactive device picker.
+     */
+    func toRestrictivePermissions() -> PeripheralPermissions {
+        let services = Set(allServiceUuids() + (optionalServices ?? []))
+        return PeripheralPermissions(allowedServices: .restricted(services))
+    }
+}
 
 /**
  * Check the given list of filters against the blocklist and throw an error if there is a match.

--- a/lib/Sources/BluetoothAction/RequestDevice.swift
+++ b/lib/Sources/BluetoothAction/RequestDevice.swift
@@ -8,7 +8,7 @@ import JsMessage
 import SecurityList
 
 struct RequestDeviceRequest: JsMessageDecodable {
-    private let rawOptionsData: [String: JsType]?
+    let rawOptionsData: [String: JsType]?
 
     static func decode(from data: [String: JsType]?) -> Self? {
         return .init(rawOptionsData: data?["options"]?.dictionary)
@@ -63,7 +63,8 @@ struct RequestDevice: BluetoothAction {
         client.stopScanning()
         await eventBus.detachListener(forKey: EventRegistrationKey.advertisement)
 
-        let peripheral = try selection.get()
+        var peripheral = try selection.get()
+        peripheral.permissions = options.toRestrictivePermissions()
         await state.putPeripheral(peripheral, replace: true)
         return RequestDeviceResponse(peripheralId: peripheral.id, name: peripheral.name)
     }

--- a/lib/Sources/BluetoothAction/RequestLEScan.swift
+++ b/lib/Sources/BluetoothAction/RequestLEScan.swift
@@ -99,9 +99,8 @@ struct RequestLEScan: BluetoothAction {
             guard options.includeAdvertisementEventInDeviceList(event) else { return }
             // TODO: Potential optimization: keep track of these devices and discard them if never connected after scanning
             await state.putPeripheral(event.peripheral, replace: false)
-            // TODO: Filter both serviceData and manufacturerData as per https://webbluetoothcg.github.io/web-bluetooth/#device-discovery
-            // This means only allowing what is in the filters if provided, and in the case of acceptAllAdvertisements only
-            // allow what is in optionalServices/optionalManufacturerData after applying the blocklist
+            // Scanning is unrestricted so clear any access permissions on the device here:
+            await state.setPermissions(.init(allowedServices: .all), on: event.peripheral.id)
             await eventBus.sendJsEvent(event.toJs(targetId: "bluetooth"))
         }
         client.startScanning(serviceUuids: options.allServiceUuids())

--- a/lib/Sources/BluetoothEngine/Errors.swift
+++ b/lib/Sources/BluetoothEngine/Errors.swift
@@ -6,6 +6,7 @@ import JsMessage
 extension BluetoothError: DomErrorConvertable {
     public var domErrorName: DomErrorName {
         switch self {
+        case .accessToServiceDenied: .security
         case .blocklisted: .security
         case .cancelled: .abort
         case .deviceNotConnected: .network

--- a/lib/Sources/BluetoothMessage/BluetoothState.swift
+++ b/lib/Sources/BluetoothMessage/BluetoothState.swift
@@ -121,6 +121,10 @@ public actor BluetoothState {
         self.peripherals[peripheralId]?.services[serviceIndex].characteristics[characteristicIndex].descriptors = descriptors
     }
 
+    public func setPermissions(_ permissions: PeripheralPermissions, on peripheralId: UUID) {
+        self.peripherals[peripheralId]?.permissions = permissions
+    }
+
     private func save(peripheralIds: Set<UUID>) async {
         guard let store else { return }
         do {

--- a/lib/Tests/BluetoothActionTests/RequestDeviceTests.swift
+++ b/lib/Tests/BluetoothActionTests/RequestDeviceTests.swift
@@ -1,0 +1,110 @@
+import Bluetooth
+@testable import BluetoothAction
+import BluetoothClient
+import BluetoothMessage
+import DevicePicker
+import EventBus
+import Foundation
+import JsMessage
+import TestHelpers
+import Testing
+
+extension Tag {
+    @Tag static var requestDevice: Self
+}
+
+@Suite(.tags(.requestDevice))
+struct RequestDeviceResponseTests {
+    @Test
+    func toJsMessage_withoutName_hasExpectedBody() throws {
+        let sut = RequestDeviceResponse(peripheralId: UUID(n: 0), name: nil)
+        let jsMessage = sut.toJsMessage()
+        let body = try #require(jsMessage.extractBody(as: NSDictionary.self))
+        let expectedResponse: NSDictionary = [
+            "uuid": "00000000-0000-beef-cafe-000000000000",
+            "name": NSNull(),
+        ]
+        #expect(body == expectedResponse)
+    }
+
+    @Test
+    func toJsMessage_withName_hasExpectedBody() throws {
+        let sut = RequestDeviceResponse(peripheralId: UUID(n: 0), name: "test-name")
+        let jsMessage = sut.toJsMessage()
+        let body = try #require(jsMessage.extractBody(as: NSDictionary.self))
+        let expectedResponse: NSDictionary = [
+            "uuid": "00000000-0000-beef-cafe-000000000000",
+            "name": "test-name",
+        ]
+        #expect(body == expectedResponse)
+    }
+}
+
+@Suite(.tags(.requestDevice))
+struct RequestDeviceTests {
+    @Test
+    func execute_withRequestForSingleService_determinesPermissionsFromInputFilters() async throws {
+        let eventBus = await selfResolvingEventBus()
+        let fakeService = FakeService(uuid: UUID(n: 10))
+        let extraServiceUuid = UUID(n: 99)
+        let fake = FakePeripheral(id: UUID(n: 0), connectionState: .connected, services: [fakeService])
+        var client = MockBluetoothClient()
+        client.onStartScanning = { _ in }
+        client.onStopScanning = { }
+        let options: [String: JsType] = [
+            "filters": .array([
+                .dictionary([
+                    "services": .array([
+                        .string(fakeService.uuid.uuidString),
+                    ]),
+                ]),
+            ]),
+            "optionalServices": .array([
+                .string(extraServiceUuid.uuidString)
+            ]),
+        ]
+        let selector = await MockDeviceSelector(onSelection: { .success(fake) })
+        let state = BluetoothState(peripherals: [fake])
+        let request = RequestDeviceRequest(rawOptionsData: options)
+        let sut = RequestDevice(request: request, selector: selector)
+
+        // Execute for a response:
+        let response = try await sut.execute(state: state, client: client, eventBus: eventBus)
+        #expect(response.peripheralId == fake.id)
+
+        // Test that the peripheral state was updated with the expected permissions:
+        let updatedPeripheral = try await state.getPeripheral(fake.id)
+        switch updatedPeripheral.permissions.allowedServices {
+        case .all:
+            Issue.record("Unexpected permissions case")
+        case let .restricted(allowedUuids):
+            #expect(allowedUuids == [fakeService.uuid, extraServiceUuid])
+        }
+    }
+}
+
+private struct MockDeviceSelector: InteractiveDeviceSelector {
+    let onSelection: () -> Result<Bluetooth.Peripheral, DeviceSelectionError>
+
+    public init(
+        onSelection: (() -> Result<Bluetooth.Peripheral, DeviceSelectionError>)? = nil,
+    ) {
+        self.onSelection = onSelection ?? { fatalError("Not implemented") }
+    }
+
+    public func awaitSelection() async -> Result<Bluetooth.Peripheral, DeviceSelectionError> {
+        onSelection()
+    }
+
+    public func makeSelection(_ identifier: UUID) async {
+        fatalError("Not implemented")
+    }
+
+    public func showAdvertisement(peripheral: Bluetooth.Peripheral, advertisement: Bluetooth.Advertisement) async {
+        fatalError("Not implemented")
+    }
+
+    public func cancel() async {
+        fatalError("Not implemented")
+    }
+}


### PR DESCRIPTION
Completes this behavior from [Mozilla Web API docs](https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth/requestDevice):
> After the user selects a device to pair in the current origin, it is only allowed to access services whose UUID was listed in the services list in any element of filters.services or in optionalServices.

This means that when a device is selected by the user via the `requestDevice` interactive picker, the services that were supplied in the filters affects the subsequent service discovery calls.

Added unit tests to cover the changes in both service discovery and request device.

Also removed the related TODOs from the scanning based APIs as the permission set is built from the `requestDevice` input options and there is no equivalent on the scanning APIs.
