### PR TITLE
Fix tests hanging on iOS 26.0

### DIFF
--- a/lib/Tests/EventBusTests/EventBusListenerTests.swift
+++ b/lib/Tests/EventBusTests/EventBusListenerTests.swift
@@ -113,7 +113,7 @@ struct EventBusListenerTests {
             let event = TestEventOne(id: "\(i)", lookup: .exact(key: systemStateKey))
             sut.enqueueEvent(event)
         }
-        let outcome = await XCTWaiter().fulfillment(of: [eventReceivedExpectation], timeout: 0.1)
+        let outcome = await XCTWaiter().fulfillment(of: [eventReceivedExpectation], timeout: 0.5)
         #expect(outcome == .completed)
         resultQueue.finish()
         // Check that the order is as expected:

--- a/lib/Tests/NavigationTests/MockAction.swift
+++ b/lib/Tests/NavigationTests/MockAction.swift
@@ -5,9 +5,9 @@ class MockAction: MockActionWithoutSourceFrame {
 
     init(
         navigationType: WKNavigationType = .other,
-        request: @escaping () -> URLRequest = { fatalError() },
-        sourceFrame: @escaping () -> WKFrameInfo = { fatalError() },
-        targetFrame: @escaping () -> WKFrameInfo? = { fatalError() }
+        request: @escaping () -> URLRequest = { fatalError("MockAction: request missing") },
+        sourceFrame: @escaping () -> WKFrameInfo = { fatalError("MockAction: sourceFrame missing") },
+        targetFrame: @escaping () -> WKFrameInfo? = { fatalError("MockAction: targetFrame missing") }
     ) {
         _sourceFrame = sourceFrame
         super.init(navigationType: navigationType, request: request, targetFrame: targetFrame)
@@ -27,8 +27,8 @@ open class MockActionWithoutSourceFrame: WKNavigationAction {
 
     init(
         navigationType: WKNavigationType = .other,
-        request: @escaping () -> URLRequest = { fatalError() },
-        targetFrame: @escaping () -> WKFrameInfo? = { fatalError() }
+        request: @escaping () -> URLRequest = { fatalError("MockActionWithoutSourceFrame: request missing") },
+        targetFrame: @escaping () -> WKFrameInfo? = { fatalError("MockActionWithoutSourceFrame: targetFrame missing") }
     ) {
         _navigationType = navigationType
         _request = request

--- a/lib/Tests/NavigationTests/MockFrameInfo.swift
+++ b/lib/Tests/NavigationTests/MockFrameInfo.swift
@@ -6,9 +6,9 @@ class MockFrameInfo: WKFrameInfo {
     let _securityOrigin: () -> WKSecurityOrigin
 
     init(
-        isMainFrame: @escaping () -> Bool = { fatalError() },
-        request: @escaping () -> URLRequest = { fatalError() },
-        securityOrigin: @escaping () -> WKSecurityOrigin = { fatalError() }
+        isMainFrame: @escaping () -> Bool = { fatalError("MockFrameInfo: isMainFrame missing") },
+        request: @escaping () -> URLRequest = { fatalError("MockFrameInfo: request missing") },
+        securityOrigin: @escaping () -> WKSecurityOrigin = { fatalError("MockFrameInfo: securityOrigin missing") }
     ) {
         _isMainFrame = isMainFrame
         _request = request

--- a/lib/Tests/NavigationTests/NavigationRequestTests.swift
+++ b/lib/Tests/NavigationTests/NavigationRequestTests.swift
@@ -81,7 +81,7 @@ struct NavigationRequestTests {
         #expect(sut == nil)
     }
 
-    @Test
+    @Test(.disabled("https://github.com/JuulLabs/topaz/issues/180"))
     func initFromAction_withNoTargetFrameAndNoSourceFrame_isNil() {
         let action = MockActionWithoutSourceFrame(
             request: { testRequest },


### PR DESCRIPTION
Since the action runners have started using Xcode 16.3 and iOS 26.0 the test runs have been stalling during simulator boot for an extended time and the CI ends up cancelled. ~Not clear what the system is doing, the unit tests themselves execute in under 4 minutes once the simulator comes up so nothing broken there.~

Found two issues:

1. one of the heavier tests (10k iterations) sometimes timeouts before the 100ms limit so need to increase that
2. one of the `Navigation` module unit tests is hanging but the ouput just halts so need to figure out which one _update: see issue #180_
