### PR TITLE
Tweak loading spinner for new UI

### DIFF
--- a/lib/Sources/App/FreshPageView.swift
+++ b/lib/Sources/App/FreshPageView.swift
@@ -22,6 +22,7 @@ struct FreshPageView: View {
         .safeAreaBarIfAvailable {
             NavBarViewV2(model: model.navBarModel)
                 .opacity(model.isLoading ? 0 : 1)
+                .disabled(model.isLoading)
                 .animation(.spring, value: model.isLoading)
                 .animation(.spring, value: keyboardPresent)
         }

--- a/lib/Sources/App/FreshPageView.swift
+++ b/lib/Sources/App/FreshPageView.swift
@@ -15,10 +15,15 @@ struct FreshPageView: View {
             Color.backgroundPrimary
                 .ignoresSafeArea(.all)
             topAlignedHeaderView
-            searchView
             if model.navBarModel.isSettingsPresented {
                 SettingsViewV2(model: model.navBarModel.settingsModel)
             }
+        }
+        .safeAreaBarIfAvailable {
+            NavBarViewV2(model: model.navBarModel)
+                .opacity(model.isLoading ? 0 : 1)
+                .animation(.spring, value: model.isLoading)
+                .animation(.spring, value: keyboardPresent)
         }
         .onTapGesture {
             // Tap outside to dismiss the keyboard
@@ -56,26 +61,16 @@ struct FreshPageView: View {
                         .foregroundStyle(Color.textPrimary)
                 }
             }
+            if model.isLoading {
+                ProgressView()
+                    .controlSize(isCompact ? .regular : .extraLarge)
+                    .tint(Color.topaz600)
+                    .padding(.top, isCompact ? 6 : 40)
+            }
             Spacer()
         }
         .padding(.top, isCompact ? 6 : 60)
         .animation(.easeIn, value: keyboardPresent)
-    }
-
-    @ViewBuilder private var searchView: some View {
-        VStack(spacing: 0) {
-            Spacer()
-            if model.isLoading {
-                ProgressView()
-                    .controlSize(.extraLarge)
-                    .tint(.white)
-                    .padding(.bottom, 30)
-                Spacer()
-            } else {
-                NavBarViewV2(model: model.navBarModel)
-            }
-        }
-        .animation(.spring, value: keyboardPresent)
     }
 }
 


### PR DESCRIPTION
## What

Updates the color of the spinner for contrast on the new white background.

Also had to refactor the layout a little for placement with the new header and the v2 navbar to be placed consistent with where it flows on the post-loading screen.

Have to look pretty close to see the white-on-white spinner in the before screencap, it's obscuring the "enabled" text:

|Before|After|
|---|---|
|<img width="300" height="606" alt="before-loading" src="https://github.com/user-attachments/assets/4ec31333-bad2-453f-8ddf-9ba3f923b416" />|<img width="300" height="606" alt="after_loading" src="https://github.com/user-attachments/assets/b5e085b9-c00e-4476-be6b-574c4d766a2e" />|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to loading spinner styling and layout positioning with no impact on business logic or data handling.
> 
> **Overview**
> Updates the loading spinner styling and layout placement for the new white background UI.
> 
> **Key changes:**
> - Changes `ProgressView` tint from white to `Color.topaz600` for visibility on the white background
> - Adjusts spinner sizing to use `.regular` in compact mode, `.extraLarge` otherwise
> - Refactors layout by removing the separate `searchView` and moving the `NavBarViewV2` into a `.safeAreaBarIfAvailable` container
> - Repositions the loading spinner within `topAlignedHeaderView` with adjusted padding (top instead of bottom)
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c5a6503188a12d27bc6f51bbbf453170f13e595. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->