### PR TITLE
Use background primary color for launch screen

### DIFF
--- a/Topaz/Assets.xcassets/LaunchBackground.colorset/Contents.json
+++ b/Topaz/Assets.xcassets/LaunchBackground.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xFA",
+          "blue" : "0xFC",
           "green" : "0xFA",
-          "red" : "0xFC"
+          "red" : "0xFA"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xFA",
+          "blue" : "0xFC",
           "green" : "0xFA",
-          "red" : "0xFC"
+          "red" : "0xFA"
         }
       },
       "idiom" : "universal"

--- a/Topaz/Assets.xcassets/LaunchBackground.colorset/Contents.json
+++ b/Topaz/Assets.xcassets/LaunchBackground.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xB1",
-          "green" : "0x4D",
-          "red" : "0x31"
+          "blue" : "0xFA",
+          "green" : "0xFA",
+          "red" : "0xFC"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xB1",
-          "green" : "0x4D",
-          "red" : "0x31"
+          "blue" : "0xFA",
+          "green" : "0xFA",
+          "red" : "0xFC"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
Uses the background defined as https://github.com/JuulLabs/topaz/blob/main/lib/Sources/Design/Colors.swift#L5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple color change for launch screen background with no functional or security implications.
> 
> **Overview**
> Updates the launch screen background color from dark blue (`#314DB1`) to the primary background color (`#FAFAFC`), aligning it with the `backgroundPrimary` color defined in the design system.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dd272e5babdd297ffc55dfabeb38d9398ad8ec7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->