### PR TITLE
Add dependencies label to release drafter config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,9 +6,10 @@ categories:
       - 'bug'
   - title: '🧰 Maintenance'
     labels:
+      - 'dependencies'
+      - 'documentation'
       - 'maintenance'
       - 'renovate'
-      - 'documentation'
 change-template: '- $TITLE (#$NUMBER)'
 exclude-labels:
   - 'skip-changelog'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Configuration-only change to release note categorization with no code or security impact.
> 
> **Overview**
> Updates the release drafter configuration to include the `dependencies` label under the '🧰 Maintenance' category. PRs tagged with `dependencies` will now appear in the maintenance section of auto-generated release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e2ce1482731268934bbf2fcd76adb414fcc75f0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->