### PR TITLE
Allow back button to go to previous open tab

### DIFF
--- a/lib/Sources/App/AppModel.swift
+++ b/lib/Sources/App/AppModel.swift
@@ -115,9 +115,13 @@ public class AppModel {
         }
         navigator.launchNewPage = { [weak self] newUrl in
             guard let self else { return }
+            let prior = self.activePageModel
             let newTab = self.tabsModel.findOrCreateTab(for: newUrl)
-            let webLoadingModel = self.buildPageModel(tabModel: newTab)
-            self.activePageModel = webLoadingModel
+            let newModel = self.buildPageModel(tabModel: newTab)
+            newModel.navBarModel.goBackToPriorPage = { [weak self] in
+                self?.activePageModel = prior
+            }
+            self.activePageModel = newModel
         }
         return NavBarModel(navigator: navigator, settingsModel: settingsModel, searchBarModel: searchBarModel, isFullscreen: lastOpenedTabWasInFullscreenMode ?? false) { newValue in
             self.lastOpenedTabWasInFullscreenMode = newValue

--- a/lib/Sources/App/NavBarModel.swift
+++ b/lib/Sources/App/NavBarModel.swift
@@ -45,8 +45,10 @@ public final class NavBarModel {
         }
     }
 
+    var goBackToPriorPage: (() -> Void)?
+
     var backButtonDisabled: Bool {
-        navigator.canGoBack == false
+        navigator.canGoBack == false && goBackToPriorPage == nil
     }
 
     var forwardButtonDisabled: Bool {
@@ -54,7 +56,11 @@ public final class NavBarModel {
     }
 
     func backButtonTapped() {
-        navigator.goBack()
+        if navigator.canGoBack {
+            navigator.goBack()
+        } else {
+            goBackToPriorPage?()
+        }
     }
 
     func forwardButtonTapped() {


### PR DESCRIPTION
Naïve implementation of tab continuity prior to support for multiple active tabs -- if a link opens a new tab, remember the prior tab and have the back button go back to the original tab.

https://github.com/user-attachments/assets/d48fbc88-8352-4842-a697-0494e565c5c0


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, contained change to navigation behavior that adds an optional fallback closure for back navigation. No security or data handling implications.
> 
> **Overview**
> Enables the back button to return to the previously active tab when a link opens a new tab, providing basic tab continuity before full multiple active tabs support.
> 
> When `launchNewPage` creates a new tab, it now captures the prior `activePageModel` and sets up a `goBackToPriorPage` closure on the new tab's `NavBarModel`. The back button logic in `NavBarModel` now falls back to this closure when `navigator.canGoBack` is false, allowing users to navigate back to the original tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b59028366e6c91ddbf31a55bcd838cb5c035edaa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->