### PR TITLE
CA-6181: Fix bug around adjusting safe area height

### DIFF
--- a/lib/Sources/App/NavBarModel.swift
+++ b/lib/Sources/App/NavBarModel.swift
@@ -18,9 +18,9 @@ public final class NavBarModel {
 
     var fullscreenButtonDisabled: Bool = false
     var isSettingsPresented: Bool = false
-    
+
     var navBarYOffset: CGFloat = 0
-    
+
     @ObservationIgnored
     private var previousKeyboardFrame: CGRect?
 
@@ -79,7 +79,7 @@ public final class NavBarModel {
             previousKeyboardFrame = frame
         }
     }
-    
+
     func backButtonTapped() {
         if navigator.canGoBack {
             navigator.goBack()

--- a/lib/Sources/App/NavBarModel.swift
+++ b/lib/Sources/App/NavBarModel.swift
@@ -3,6 +3,7 @@ import Observation
 import Settings
 import SwiftUI
 import WebView
+import UIHelpers
 
 @MainActor
 @Observable
@@ -13,9 +14,15 @@ public final class NavBarModel {
     let pullDrawer: PullDrawerModel
 
     let navigator: WebNavigator
+    let keyboardObserver: KeyboardObserver
 
     var fullscreenButtonDisabled: Bool = false
     var isSettingsPresented: Bool = false
+    
+    var navBarYOffset: CGFloat = 0
+    
+    @ObservationIgnored
+    private var previousKeyboardFrame: CGRect?
 
     private(set) var isFullscreen: Bool = false
     private let onFullscreenChanged: (Bool) -> Void
@@ -33,6 +40,7 @@ public final class NavBarModel {
         self.settingsModel = settingsModel
         self.isFullscreen = isFullscreen
         self.onFullscreenChanged = onFullscreenChanged
+        self.keyboardObserver = .init()
         self.settingsModel.dismiss = { [weak self] in
             self?.isSettingsPresented = false
         }
@@ -53,6 +61,23 @@ public final class NavBarModel {
         navigator.canGoForward == false
     }
 
+    // TODO: This is a hack. It's correcting for a possible bug in SwiftUI that incorrectly adjusts
+    // the height of the safe area after a web view text field loses focus.
+    func task() async {
+        for await frame in keyboardObserver.stream() {
+            guard Task.isCancelled == false else {
+                keyboardObserver.endStream()
+                return
+            }
+            if let frame, let previousKeyboardFrame, previousKeyboardFrame.height > frame.height {
+                navBarYOffset = -(previousKeyboardFrame.height - frame.height)
+            } else {
+                navBarYOffset = 0
+            }
+            previousKeyboardFrame = frame
+        }
+    }
+    
     func backButtonTapped() {
         navigator.goBack()
     }

--- a/lib/Sources/App/v2/NavBarViewV2.swift
+++ b/lib/Sources/App/v2/NavBarViewV2.swift
@@ -38,6 +38,10 @@ struct NavBarViewV2: View {
         .padding(.bottom, 6)
         .frame(maxWidth: .infinity)
         .embedInNavigationBackground(keyboardPresent: keyboardPresent)
+        .offset(y: model.navBarYOffset)
+        .task {
+            await model.task()
+        }
     }
 }
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/432c27a6-a064-481b-a2ce-70f049671792


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only workaround for a layout bug with no security or data handling implications. The change is isolated to navigation bar positioning logic.
> 
> **Overview**
> Fixes a SwiftUI bug where the navigation bar was incorrectly positioned after a web view text field loses focus. The safe area height adjustment was causing the nav bar to appear floating above the bottom of the screen.
> 
> Adds a `KeyboardObserver` to `NavBarModel` that tracks keyboard frame changes. When the keyboard height decreases (indicating the keyboard is dismissing), it calculates a compensating Y offset (`navBarYOffset`) and applies it to the navigation bar view. This manually corrects for SwiftUI's incorrect safe area calculation.
> 
> The fix is marked as a temporary workaround ("hack") in the code comments pending a proper SwiftUI fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2514b831cdc9370af09452758458c56b6735c7d1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->