### PR TITLE
fix(ios): transparent search bar background over web content

### DIFF
--- a/lib/Sources/App/v2/SearchBarViewV2.swift
+++ b/lib/Sources/App/v2/SearchBarViewV2.swift
@@ -39,10 +39,6 @@ struct SearchBarViewV2: View {
         .padding(.horizontal, 16)
         .padding(.vertical, 6)
         .frame(maxWidth: .infinity, maxHeight: 48)
-        .background(
-            RoundedRectangle(cornerRadius: 24)
-                .fill(Color.cellFillPrimary)
-        )
         .overlay(
             RoundedRectangle(cornerRadius: 24)
                 .stroke(Color.white, lineWidth: 0.25)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The v2 search bar used `Color.cellFillPrimary` as a filled rounded rectangle behind the field, which reads as a solid light/white bar over the page. That fill was removed so the bar is transparent; the existing thin white stroke remains so the control still has a defined outline against varied page backgrounds.

## Testing

- Not run (Swift toolchain unavailable in this environment). Please verify on device/simulator over a few web pages.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56e7eb6a-77b6-4942-9510-7072fa882873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56e7eb6a-77b6-4942-9510-7072fa882873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

