### PR TITLE
Opt out of iPad multitasking for Topaz

### DIFF
--- a/Topaz/Info.plist
+++ b/Topaz/Info.plist
@@ -11,6 +11,8 @@
 		<key>NSAllowsArbitraryLoadsInWebContent</key>
 		<true/>
 	</dict>
+	<key>UIRequiresFullScreen</key>
+	<true/>
 	<key>UILaunchScreen</key>
 	<dict>
 		<key>UIColorName</key>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets `UIRequiresFullScreen` to `true` in the app `Info.plist` so Topaz does not participate in iPad Split View, Slide Over, or other multitasking layouts that shrink the window.

## Context

Apple documents this key as the explicit way to require a full-screen experience on iPad when the app is not designed for resizable multitasking.

## Testing

- Not run (plist-only change; verify on iPad simulator or device that the app launches full screen only).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b597d64-84d9-4d95-9c28-a78365d2f860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b597d64-84d9-4d95-9c28-a78365d2f860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

