### PR TITLE
Fix Web Bluetooth breaking after in-app back navigation

### DIFF
--- a/lib/Sources/WebView/Coordinator.swift
+++ b/lib/Sources/WebView/Coordinator.swift
@@ -43,8 +43,6 @@ public class Coordinator: NSObject, NavigationEngineDelegate {
         viewModel = nil
         detachOldHandler(from: webView)
         authorize = { false }
-        webView.configuration.userContentController.removeAllScriptMessageHandlers()
-        webView.configuration.userContentController.removeAllUserScripts()
     }
 
     func update(webView: WKWebView, model: WebPageModel) {


### PR DESCRIPTION
Bug was introduced by #243 

WebPageModel owns a long-lived WKWebViewConfiguration that is reused every time SwiftUI rebuilds the underlying WKWebView. Coordinator's deinitialize calls removeAllUserScripts() on that configuration's userContentController, which wipes the Bluetooth polyfill.

When a user navigates to a new host and then presses the in-app back button, the prior WebPageModel is used to construct a fresh WKWebView with its now-empty configuration.

The script cleanup was incorrectly placed defensive code. Cleanup is handled definitively by the message processors on detach. Tying the teardown to the view is just plain wrong as it is owned by the model.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small bug fix removing redundant cleanup code; no security or data handling implications.
> 
> **Overview**
> Removes incorrect script cleanup calls from `Coordinator.deinitialize()` that were causing Web Bluetooth to break after in-app back navigation.
> 
> The `removeAllScriptMessageHandlers()` and `removeAllUserScripts()` calls were wiping the Bluetooth polyfill from the shared `WKWebViewConfiguration` (owned by `WebPageModel`) when a webview was deinitialized. Since the configuration is long-lived and reused for new webviews, subsequent navigation would create webviews with an empty configuration. The cleanup is already properly handled by message processors on detach, making these calls both incorrect and redundant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 223ed6ba099a83f96ba773bb87ada5b641f1520d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->