### PR TITLE
Consolidate logging and expose it on debug builds

### DIFF
--- a/Topaz/Info.plist
+++ b/Topaz/Info.plist
@@ -19,6 +19,21 @@
 				</dict>
 			</dict>
 		</dict>
+		<key>Topaz</key>
+		<dict>
+			<key>DEFAULT-OPTIONS</key>
+			<dict>
+				<key>Enable-Private-Data</key>
+				<true/>
+				<key>Level</key>
+				<dict>
+					<key>Enable</key>
+					<string>Debug</string>
+					<key>Persist</key>
+					<string>Debug</string>
+				</dict>
+			</dict>
+		</dict>
 	</dict>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>

--- a/Topaz/TopazMain.swift
+++ b/Topaz/TopazMain.swift
@@ -39,7 +39,7 @@ private func processorFactory(deviceSelector: DeviceSelector) -> JsMessageProces
     JsMessageProcessorFactory(
         builders: [
             BluetoothEngine.handlerName: { _ in
-                let eventBus = EventBus()
+                let eventBus = EventBus(enableDebugLogging: appConfig.enableDebugLogging)
                 return BluetoothEngine(
                     eventBus: eventBus,
                     state: BluetoothState(securityList: .shared, store: debouncedJsonFileStorage()),

--- a/lib/Sources/App/AppModel.swift
+++ b/lib/Sources/App/AppModel.swift
@@ -17,7 +17,7 @@ import VirtualKeyboard
 import WebKit
 import WebView
 
-private let log = Logger(subsystem: "App", category: "AppModel")
+private let log = Logger(subsystem: "Topaz", category: "AppModel")
 
 @MainActor
 @Observable

--- a/lib/Sources/BluetoothAction/RequestLEScan.swift
+++ b/lib/Sources/BluetoothAction/RequestLEScan.swift
@@ -5,6 +5,9 @@ import EventBus
 import Foundation
 import JsMessage
 import SecurityList
+import OSLog
+
+private let log = Logger(subsystem: "Topaz", category: "RequestLEScan")
 
 struct RequestLEScanOptions: JsMessageDecodable {
     private let rawFilters: [JsType]
@@ -97,6 +100,7 @@ struct RequestLEScan: BluetoothAction {
         await eventBus.attachEventListener(forKey: .advertisement) { (result: Result<AdvertisementEvent, any Error>) in
             guard case let .success(event) = result else { return }
             guard options.includeAdvertisementEventInDeviceList(event) else { return }
+            log.debug("Advertisement: \(event.advertisement.debugDump, privacy: .public)")
             // TODO: Potential optimization: keep track of these devices and discard them if never connected after scanning
             await state.putPeripheral(event.peripheral, replace: false)
             // Scanning is unrestricted so clear any access permissions on the device here:
@@ -115,5 +119,11 @@ struct RequestLEScan: BluetoothAction {
         client.stopScanning()
         await eventBus.detachListener(forKey: EventRegistrationKey.advertisement)
         return .stop
+    }
+}
+
+extension Advertisement {
+    var debugDump: String {
+        "peripheralId=\(peripheralId) peripheralName=\(peripheralName) rssi=\(rssi) isConnectable=\(isConnectable) localName=\(localName) manufacturerData=\(manufacturerData?.description) overflowServiceUUIDs=\(overflowServiceUUIDs) serviceData=\(serviceData.description) serviceUUIDs=\(serviceUUIDs) solicitedServiceUUIDs=\(solicitedServiceUUIDs) txPowerLevel=\(txPowerLevel)"
     }
 }

--- a/lib/Sources/BluetoothAction/RequestLEScan.swift
+++ b/lib/Sources/BluetoothAction/RequestLEScan.swift
@@ -5,9 +5,6 @@ import EventBus
 import Foundation
 import JsMessage
 import SecurityList
-import OSLog
-
-private let log = Logger(subsystem: "Topaz", category: "RequestLEScan")
 
 struct RequestLEScanOptions: JsMessageDecodable {
     private let rawFilters: [JsType]
@@ -100,7 +97,6 @@ struct RequestLEScan: BluetoothAction {
         await eventBus.attachEventListener(forKey: .advertisement) { (result: Result<AdvertisementEvent, any Error>) in
             guard case let .success(event) = result else { return }
             guard options.includeAdvertisementEventInDeviceList(event) else { return }
-            log.debug("Advertisement: \(event.advertisement.debugDump, privacy: .public)")
             // TODO: Potential optimization: keep track of these devices and discard them if never connected after scanning
             await state.putPeripheral(event.peripheral, replace: false)
             // Scanning is unrestricted so clear any access permissions on the device here:
@@ -119,11 +115,5 @@ struct RequestLEScan: BluetoothAction {
         client.stopScanning()
         await eventBus.detachListener(forKey: EventRegistrationKey.advertisement)
         return .stop
-    }
-}
-
-extension Advertisement {
-    var debugDump: String {
-        "peripheralId=\(peripheralId) peripheralName=\(peripheralName) rssi=\(rssi) isConnectable=\(isConnectable) localName=\(localName) manufacturerData=\(manufacturerData?.description) overflowServiceUUIDs=\(overflowServiceUUIDs) serviceData=\(serviceData.description) serviceUUIDs=\(serviceUUIDs) solicitedServiceUUIDs=\(solicitedServiceUUIDs) txPowerLevel=\(txPowerLevel)"
     }
 }

--- a/lib/Sources/BluetoothEngine/BluetoothEngine.swift
+++ b/lib/Sources/BluetoothEngine/BluetoothEngine.swift
@@ -8,7 +8,7 @@ import Foundation
 import JsMessage
 import OSLog
 
-private let messageLog = Logger(subsystem: "BluetoothEngine", category: "Message")
+private let messageLog = Logger(subsystem: "Topaz", category: "BluetoothEngine")
 
 /**
  Main engine - owns state, integrates web API with native API

--- a/lib/Sources/BluetoothMessage/BluetoothState.swift
+++ b/lib/Sources/BluetoothMessage/BluetoothState.swift
@@ -4,7 +4,7 @@ import Helpers
 import OSLog
 import SecurityList
 
-private let log = Logger(subsystem: "BluetoothMessage", category: "BluetoothState")
+private let log = Logger(subsystem: "Topaz", category: "BluetoothState")
 
 /**
  Represents the current state of the bluetooth system.

--- a/lib/Sources/Design/FontRegistry.swift
+++ b/lib/Sources/Design/FontRegistry.swift
@@ -2,7 +2,7 @@ import CoreText
 import Foundation
 import OSLog
 
-let fontLogger = Logger(subsystem: "Design", category: "FontRegistry")
+let fontLogger = Logger(subsystem: "Topaz", category: "FontRegistry")
 
 /// Invoke this from main app launch to load the fonts from the SPM bundle
 public func registerFonts() {

--- a/lib/Sources/EventBus/EventBus.swift
+++ b/lib/Sources/EventBus/EventBus.swift
@@ -2,7 +2,7 @@ import Bluetooth
 import JsMessage
 import OSLog
 
-private let eventLog = Logger(subsystem: "EventBus", category: "Event")
+private let eventLog = Logger(subsystem: "Topaz", category: "EventBus")
 
 public actor EventBus {
     private enum StaticPromiseKey { case allEvents }

--- a/lib/Sources/VirtualKeyboard/VirtualKeyboard.swift
+++ b/lib/Sources/VirtualKeyboard/VirtualKeyboard.swift
@@ -5,7 +5,7 @@ import OSLog
 import UIHelpers
 import UIKit
 
-private let messageLog = Logger(subsystem: "VirtualKeyboard", category: "Message")
+private let messageLog = Logger(subsystem: "Topaz", category: "VirtualKeyboard")
 
 /**
  * https://www.w3.org/TR/virtual-keyboard/#the-virtualkeyboard-interface


### PR DESCRIPTION
Renames the sub-system for all the various non-js logs as "Topaz" and adds them to the debug build log persistence. So we will have the existing `JsMessage` logs for all the Js related stuff, and `Topaz` logs for all the app native stuff. I am leaving `WebView` logs alone (and not persisted) as they are usually not very useful and crazy noisy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging identifiers and debug plist settings only; no runtime behavior beyond aligning EventBus debug logging with existing app config.
> 
> **Overview**
> Unifies native **OSLog** output under the **`Topaz`** subsystem (with per-module categories such as `AppModel`, `BluetoothEngine`, `EventBus`) instead of separate subsystem names per package.
> 
> Adds **`OSLogPreferences`** for **`Topaz`** in **`Info.plist`** so debug builds persist **`Topaz`** logs at **Debug** level with private data enabled, matching the existing **`JsMessage`** configuration. **`WebView`** logging is intentionally unchanged.
> 
> Wires **`EventBus(enableDebugLogging: appConfig.enableDebugLogging)`** when constructing the Bluetooth stack so event-bus debug logs follow the same app debug flag as the engine and virtual keyboard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8a33c12d9b3a9c5dd146d83f606ffcaa805dece. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->