### PR TITLE
Fix iOS search bar background transparency

### DIFF
--- a/lib/Sources/App/SearchBarView.swift
+++ b/lib/Sources/App/SearchBarView.swift
@@ -54,7 +54,7 @@ struct SearchBarView: View {
             }
         }
         .padding(12)
-        .background(.white)
+        .background(.clear)
         .cornerRadius(24)
         .frame(maxWidth: .infinity, minHeight: 48)
         .animation(.interactiveSpring, value: model.stopOrReloadMode)

--- a/lib/Sources/App/v2/SearchBarViewV2.swift
+++ b/lib/Sources/App/v2/SearchBarViewV2.swift
@@ -53,14 +53,7 @@ struct SearchBarViewV2: View {
         .padding(.horizontal, 16)
         .padding(.vertical, 6)
         .frame(maxWidth: .infinity, maxHeight: 48)
-        .background(
-            RoundedRectangle(cornerRadius: 24)
-                .fill(Color.cellFillPrimary)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 24)
-                .stroke(Color.white, lineWidth: 0.25)
-        )
+        .background(Color.clear)
         .synchronize($model.focusedField, $focusedField)
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove the filled background from the V2 search bar so it renders transparent over page content
- remove the legacy search bar hardcoded white background for consistency with transparent styling

## Testing
- `swift test` *(fails in cloud agent: `swift: command not found`)*
- manually validated by code inspection against the affected SwiftUI views used in `WebContainerView` and `FreshPageView`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d10ba5ab-78f9-4d99-b369-68bf6a0c8fc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d10ba5ab-78f9-4d99-b369-68bf6a0c8fc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

