### PR TITLE
CA-6409: Add workaround for Google SSO

### DIFF
--- a/lib/Sources/WebView/Coordinator.swift
+++ b/lib/Sources/WebView/Coordinator.swift
@@ -47,6 +47,7 @@ public class Coordinator: NSObject, NavigationEngineDelegate {
 
     func update(webView: WKWebView, model: WebPageModel) {
         // TODO: load when observed model url changes only
+        webView.customUserAgent = model.customUserAgent(for: model.url)
         webView.load(URLRequest(url: model.url))
     }
 
@@ -73,6 +74,10 @@ public class Coordinator: NSObject, NavigationEngineDelegate {
     // MARK: - NavigationEngineDelegate
 
     public func didInitiateNavigation(_ navigation: NavigationItem, in webView: WKWebView) {
+        if let viewModel {
+            webView.customUserAgent = viewModel.customUserAgent(for: navigation.request.url)
+        }
+
         switch navigation.request.kind {
         case .newWindow:
             // Will trigger load of an entire new tab container so no need for any action

--- a/lib/Sources/WebView/WebPageModel.swift
+++ b/lib/Sources/WebView/WebPageModel.swift
@@ -34,10 +34,15 @@ public class WebPageModel: Identifiable {
     let messageProcessorFactory: JsMessageProcessorFactory
 
     // TODO: dynamically construct this
-    let customUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Version/3.9.0 Topaz/3.9.0"
+    private let topazCustomUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Version/3.9.0 Topaz/3.9.0"
+    private let googleCompatibleUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Version/26.0 Safari/605.1.15"
 
     public var hostname: String {
         url.host(percentEncoded: false) ?? "unknown"
+    }
+
+    var customUserAgent: String {
+        customUserAgent(for: url)
     }
 
     public init(
@@ -59,6 +64,10 @@ public class WebPageModel: Identifiable {
 
     public func loadNewPage(url: URL) {
         self.url = url
+    }
+
+    func customUserAgent(for url: URL) -> String {
+        usesGoogleCompatibleUserAgent(for: url) ? googleCompatibleUserAgent : topazCustomUserAgent
     }
 
     func createWebView() -> WKWebView {
@@ -114,5 +123,39 @@ public class WebPageModel: Identifiable {
     private func closePermissionsRequest(allowed: Bool) {
         permissionsRequest?.resume(returning: allowed)
         permissionsRequest = nil
+    }
+
+    // TODO: This is a workaround for Google SSO whereby Topaz is not currently recognized as a
+    // "secure browser." This will switch the user agent sent in requests to Safari when Topaz
+    // detects the user is trying to sign in to juul.com via Google SSO.
+    private func usesGoogleCompatibleUserAgent(for url: URL) -> Bool {
+        guard let host = url.host?.lowercased() else {
+            return false
+        }
+        let path = url.path.lowercased()
+        let query = url.query?.lowercased() ?? ""
+
+        if (host == "juul.com" || host.hasSuffix(".juul.com")) && path == "/spree_user/auth/google_oauth2" {
+            return true
+        }
+
+        if host == "accounts.google.com" || host.hasSuffix(".accounts.google.com") {
+            return true
+        }
+
+        if host == "accounts.youtube.com" || host.hasSuffix(".accounts.youtube.com") {
+            return true
+        }
+
+        guard host == "google.com" || host.hasSuffix(".google.com") else {
+            return false
+        }
+
+        return path.contains("/o/oauth") ||
+            path.contains("/oauth") ||
+            path.contains("/signin") ||
+            path.contains("/gsi/") ||
+            query.contains("client_id=") ||
+            query.contains("response_type=")
     }
 }


### PR DESCRIPTION
Google SSO whitelists "secure browsers." We haven't got on this list yet, but still want users to be able to use Google SSO. This workaround temporarily switches the user agent to Safari if Topaz detects a user is attempting to sign in via Google SSO.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication-related navigation and broad Google host/path heuristics; misclassification could send the wrong UA on unrelated Google pages or miss edge SSO URLs.
> 
> **Overview**
> Adds a **temporary Google SSO workaround** by choosing the `WKWebView` user agent per URL instead of always sending the Topaz string.
> 
> `WebPageModel` now keeps a default Topaz UA and a **Safari-style** UA, with `customUserAgent(for:)` returning the Safari string when `usesGoogleCompatibleUserAgent` matches juul.com Google OAuth entry, Google/YouTube account hosts, or common Google OAuth/sign-in URL patterns. **`Coordinator`** sets `webView.customUserAgent` from that helper on page updates and at the start of each navigation so redirects through Google still get the compatible agent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7fcc3f54f06f71b71b6140e5d31a88df8cf1493. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->