### PR TITLE
CA-6409: Add an API to allow a site to change the user agent to Safari

### DIFF
--- a/lib/Javascript/src/Topaz.ts
+++ b/lib/Javascript/src/Topaz.ts
@@ -2,6 +2,9 @@ import { Bluetooth } from "./Bluetooth";
 import { processEvent, TargetedEvent } from "./EventSink";
 import { setupLogging } from "./Logging";
 import { VirtualKeyboard } from "./VirtualKeyboard";
+import { topazRequest } from "./WebKit";
+
+type UserAgentMode = "topaz" | "safari";
 
 export class Topaz {
     bluetooth: Bluetooth;
@@ -14,6 +17,10 @@ export class Topaz {
 
     sendEvent = (event: TargetedEvent) => {
         processEvent(event);
+    }
+
+    setUserAgentMode = async (mode: UserAgentMode): Promise<void> => {
+        await topazRequest<{ mode: UserAgentMode }, void>("setUserAgentMode", { mode });
     }
 }
 

--- a/lib/Javascript/src/WebKit.ts
+++ b/lib/Javascript/src/WebKit.ts
@@ -5,6 +5,7 @@ declare namespace window.webkit.messageHandlers {
     const bluetooth: Channel<BluetoothMessage>;
     const logging: Channel<LogMessage>;
     const keyboard: Channel<VirtualKeyboardMessage>;
+    const topaz: Channel<TopazMessage>;
 }
 
 interface Channel<Message> {
@@ -57,6 +58,24 @@ export const virtualKeyboardRequest = function <Request, Response>(
     data?: Request,
 ): Promise<Response> {
     return window.webkit.messageHandlers.keyboard.postMessage<Response>({
+        action: action,
+        data: data
+    }).catch(rethrowAsDOMException);
+}
+
+
+// Topaz Channel
+
+type TopazMessage = {
+    action: string;
+    data?: any;
+}
+
+export const topazRequest = function <Request, Response>(
+    action: string,
+    data?: Request,
+): Promise<Response> {
+    return window.webkit.messageHandlers.topaz.postMessage<Response>({
         action: action,
         data: data
     }).catch(rethrowAsDOMException);

--- a/lib/Sources/WebView/Coordinator.swift
+++ b/lib/Sources/WebView/Coordinator.swift
@@ -9,9 +9,11 @@ import WebKit
 @MainActor
 public class Coordinator: NSObject, NavigationEngineDelegate {
     private let world: WKContentWorld = .page
+    private let topazHandlerName = "topaz"
     private var messageProcessorFactory: JsMessageProcessorFactory!
     private var contextId: JsContextIdentifier!
     private var scriptHandler: ScriptHandler?
+    private var topazScriptHandler: TopazScriptHandler?
     private var viewModel: WebPageModel?
     private var navigationEngine: NavigationEngine?
     private var authorize: () async -> Bool = { false }
@@ -29,6 +31,13 @@ public class Coordinator: NSObject, NavigationEngineDelegate {
         webView.uiDelegate = navigationEngine
         webView.customUserAgent = model.customUserAgent
         model.navigator.startObservingNavigationState(of: webView)
+        let topazScriptHandler = TopazScriptHandler(webView: webView, model: model)
+        self.topazScriptHandler = topazScriptHandler
+        webView.configuration.userContentController.addScriptMessageHandler(
+            topazScriptHandler,
+            contentWorld: world,
+            name: topazHandlerName
+        )
 
         authorize = {
             await model.requestAuthorization()
@@ -42,10 +51,16 @@ public class Coordinator: NSObject, NavigationEngineDelegate {
         webView.uiDelegate = nil
         viewModel = nil
         detachOldHandler(from: webView)
+        webView.configuration.userContentController.removeScriptMessageHandler(
+            forName: topazHandlerName,
+            contentWorld: world
+        )
+        topazScriptHandler = nil
         authorize = { false }
     }
 
     func update(webView: WKWebView, model: WebPageModel) {
+        webView.customUserAgent = model.customUserAgent
         // TODO: load when observed model url changes only
         webView.load(URLRequest(url: model.url))
     }
@@ -102,6 +117,35 @@ public class Coordinator: NSObject, NavigationEngineDelegate {
 
     public func completedDownload(for url: URL) {
         viewModel?.isDownloadsPresented = true
+    }
+}
+
+@MainActor
+private final class TopazScriptHandler: NSObject, WKScriptMessageHandlerWithReply {
+    private weak var webView: WKWebView?
+    private weak var model: WebPageModel?
+
+    init(webView: WKWebView, model: WebPageModel) {
+        self.webView = webView
+        self.model = model
+    }
+
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage
+    ) async -> (Any?, String?) {
+        guard
+            let request = message.toRequest(),
+            request.body["action"]?.string == "setUserAgentMode",
+            let requestedMode = request.body["data"]?.dictionary?["mode"]?.string,
+            let mode = WebPageModel.UserAgentMode(rawValue: requestedMode),
+            let model
+        else {
+            return (nil, "Unable to parse request")
+        }
+        model.setUserAgentMode(mode)
+        webView?.customUserAgent = model.customUserAgent
+        return ([String: any JsConvertable]().jsValue, nil)
     }
 }
 

--- a/lib/Sources/WebView/Resources/Generated/BluetoothPolyfill.js
+++ b/lib/Sources/WebView/Resources/Generated/BluetoothPolyfill.js
@@ -26,16 +26,26 @@ const virtualKeyboardRequest = function (action, data) {
         data: data
     }).catch(rethrowAsDOMException);
 };
+const topazRequest = function (action, data) {
+    return window.webkit.messageHandlers.topaz.postMessage({
+        action: action,
+        data: data
+    }).catch(rethrowAsDOMException);
+};
 
+// Converts Uint8Array to base64 string
 const uint8ArrayToBase64 = (uint8array) => {
     return btoa(String.fromCharCode(...uint8array));
 };
+// Converts base64 string to Uint8Array
 const base64ToUint8Array = (base64) => {
     return Uint8Array.from(atob(base64), (m) => m.codePointAt(0));
 };
+// Converts ArrayBuffer to base64 string
 const arrayBufferToBase64 = (buffer) => {
     return uint8ArrayToBase64(new Uint8Array(buffer));
 };
+// Converts base64 string to DataView
 const base64ToDataView = (base64) => {
     return new DataView(base64ToUint8Array(base64).buffer);
 };
@@ -43,25 +53,63 @@ function copyOf(data) {
     return new DataView(data.buffer.slice(0));
 }
 
+// https://developer.mozilla.org/en-US/docs/Web/API/BluetoothRemoteGATTDescriptor
 class BluetoothRemoteGATTDescriptor {
+    characteristic;
+    uuid;
+    // https://developer.mozilla.org/en-US/docs/Web/API/BluetoothRemoteGATTDescriptor/value
+    value;
     constructor(characteristic, uuid) {
         this.characteristic = characteristic;
         this.uuid = uuid;
-        this.readValue = async () => {
-            const response = await bluetoothRequest('readDescriptor', {
-                device: this.characteristic.service.device.id,
-                service: this.characteristic.service.uuid,
-                characteristic: this.characteristic.uuid,
-                instance: this.characteristic.instance,
-                descriptor: this.uuid
-            });
-            this.value = base64ToDataView(response);
-            return copyOf(this.value);
-        };
         this.value = null;
     }
+    // https://developer.mozilla.org/en-US/docs/Web/API/BluetoothRemoteGATTCharacteristic/readValue
+    readValue = async () => {
+        const response = await bluetoothRequest('readDescriptor', {
+            device: this.characteristic.service.device.id,
+            service: this.characteristic.service.uuid,
+            characteristic: this.characteristic.uuid,
+            instance: this.characteristic.instance,
+            descriptor: this.uuid
+        });
+        this.value = base64ToDataView(response);
+        return copyOf(this.value);
+    };
 }
 
+// Adaptation of https://github.com/thegecko/webbluetooth/blob/4e2b9cac02cd1a40ee237f2c8d4fe27b60cab1d4/src/uuid.ts
+// with additional known UUIDs added from:
+// https://github.com/WebBluetoothCG/registries/blob/228b62c31c177c9b770b79896aec9ef660f62216/gatt_assigned_services.txt
+// https://github.com/WebBluetoothCG/registries/blob/228b62c31c177c9b770b79896aec9ef660f62216/gatt_assigned_characteristics.txt
+// https://github.com/WebBluetoothCG/registries/blob/228b62c31c177c9b770b79896aec9ef660f62216/gatt_assigned_descriptors.txt
+/*
+* Node Web Bluetooth
+* Copyright (c) 2017 Rob Moran
+*
+* The MIT License (MIT)
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+/**
+ * Known services enum
+ */
 var bluetoothServices;
 (function (bluetoothServices) {
     bluetoothServices[bluetoothServices["alert_notification"] = 6161] = "alert_notification";
@@ -104,6 +152,9 @@ var bluetoothServices;
     bluetoothServices[bluetoothServices["user_data"] = 6172] = "user_data";
     bluetoothServices[bluetoothServices["weight_scale"] = 6173] = "weight_scale";
 })(bluetoothServices || (bluetoothServices = {}));
+/**
+ * Known characteristics enum
+ */
 var bluetoothCharacteristics;
 (function (bluetoothCharacteristics) {
     bluetoothCharacteristics[bluetoothCharacteristics["aerobic_heart_rate_lower_limit"] = 10878] = "aerobic_heart_rate_lower_limit";
@@ -322,6 +373,9 @@ var bluetoothCharacteristics;
     bluetoothCharacteristics[bluetoothCharacteristics["weight_scale_feature"] = 10910] = "weight_scale_feature";
     bluetoothCharacteristics[bluetoothCharacteristics["wind_chill"] = 10873] = "wind_chill";
 })(bluetoothCharacteristics || (bluetoothCharacteristics = {}));
+/**
+ * Known descriptors enum
+ */
 var bluetoothDescriptors;
 (function (bluetoothDescriptors) {
     bluetoothDescriptors[bluetoothDescriptors["es_configuration"] = 10507] = "es_configuration";
@@ -340,6 +394,11 @@ var bluetoothDescriptors;
     bluetoothDescriptors[bluetoothDescriptors["valid_range"] = 10502] = "valid_range";
     bluetoothDescriptors[bluetoothDescriptors["value_trigger_setting"] = 10506] = "value_trigger_setting";
 })(bluetoothDescriptors || (bluetoothDescriptors = {}));
+/**
+ * Gets a canonical UUID from a partial UUID in string or hex format
+ * @param alias The partial UUID
+ * @returns canonical UUID
+ */
 const canonicalUUID = (alias) => {
     if (typeof alias === 'number')
         alias = alias.toString(16);
@@ -350,19 +409,37 @@ const canonicalUUID = (alias) => {
         alias = alias.match(/^([0-9a-f]{8})([0-9a-f]{4})([0-9a-f]{4})([0-9a-f]{4})([0-9a-f]{12})$/).splice(1).join('-');
     return alias;
 };
+/**
+ * Gets a canonical service UUID from a known service name or partial UUID in string or hex format
+ * @param name The known service name
+ * @returns canonical UUID
+ */
 const getService = (name) => {
+    // Check for string as enums also allow a reverse lookup which will match any numbers passed in
     if (typeof name === 'string' && bluetoothServices[name]) {
         name = bluetoothServices[name];
     }
     return canonicalUUID(name);
 };
+/**
+ * Gets a canonical characteristic UUID from a known characteristic name or partial UUID in string or hex format
+ * @param name The known characteristic name
+ * @returns canonical UUID
+ */
 const getCharacteristic = (name) => {
+    // Check for string as enums also allow a reverse lookup which will match any numbers passed in
     if (typeof name === 'string' && bluetoothCharacteristics[name]) {
         name = bluetoothCharacteristics[name];
     }
     return canonicalUUID(name);
 };
+/**
+ * Gets a canonical descriptor UUID from a known descriptor name or partial UUID in string or hex format
+ * @param name The known descriptor name
+ * @returns canonical UUID
+ */
 const getDescriptor = (name) => {
+    // Check for string as enums also allow a reverse lookup which will match any numbers passed in
     if (typeof name === 'string' && bluetoothDescriptors[name]) {
         name = bluetoothDescriptors[name];
     }
@@ -375,42 +452,6 @@ const BluetoothUUID = {
     canonicalUUID
 };
 
-/******************************************************************************
-Copyright (c) Microsoft Corporation.
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
-AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
-LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
-OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-PERFORMANCE OF THIS SOFTWARE.
-***************************************************************************** */
-/* global Reflect, Promise, SuppressedError, Symbol, Iterator */
-
-
-function __classPrivateFieldGet(receiver, state, kind, f) {
-    if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
-    if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
-    return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
-}
-
-function __classPrivateFieldSet(receiver, state, value, kind, f) {
-    if (kind === "m") throw new TypeError("Private method is not writable");
-    if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
-    if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
-    return (kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value)), value;
-}
-
-typeof SuppressedError === "function" ? SuppressedError : function (error, suppressed, message) {
-    var e = new Error(message);
-    return e.name = "SuppressedError", e.error = error, e.suppressed = suppressed, e;
-};
-
-var _Store_devices;
 const characteristicKey = (uuid, instance) => {
     return uuid + '.' + instance;
 };
@@ -418,71 +459,73 @@ const keyForCharacteristic = (characteristic) => {
     return characteristicKey(characteristic.uuid, characteristic.instance);
 };
 class Store {
+    #devices;
     constructor() {
-        _Store_devices.set(this, void 0);
-        this.getDevice = (uuid) => {
-            var _a;
-            return (_a = __classPrivateFieldGet(this, _Store_devices, "f").get(uuid)) === null || _a === void 0 ? void 0 : _a.device;
-        };
-        this.addDevice = (device) => {
-            this.removeDevice(device.id);
-            __classPrivateFieldGet(this, _Store_devices, "f").set(device.id, { uuid: device.id, device, services: new Map() });
-        };
-        this.removeDevice = (uuid) => {
-            const deviceRecord = __classPrivateFieldGet(this, _Store_devices, "f").get(uuid);
-            __classPrivateFieldGet(this, _Store_devices, "f").delete(uuid);
-            return deviceRecord === null || deviceRecord === void 0 ? void 0 : deviceRecord.device;
-        };
-        this.getService = (deviceUuid, serviceUuid) => {
-            var _a, _b;
-            return (_b = (_a = __classPrivateFieldGet(this, _Store_devices, "f").get(deviceUuid)) === null || _a === void 0 ? void 0 : _a.services.get(serviceUuid)) === null || _b === void 0 ? void 0 : _b.service;
-        };
-        this.addService = (service) => {
-            const deviceRecord = __classPrivateFieldGet(this, _Store_devices, "f").get(service.device.id);
-            if (!deviceRecord) {
-                throw new ReferenceError(`Device ${service.device.id} not found`);
-            }
-            deviceRecord.services.set(service.uuid, { uuid: service.uuid, service, characteristics: new Map() });
-        };
-        this.getCharacteristic = (service, uuid, instance) => {
-            var _a, _b, _c;
-            return (_c = (_b = (_a = __classPrivateFieldGet(this, _Store_devices, "f").get(service.device.id)) === null || _a === void 0 ? void 0 : _a.services.get(service.uuid)) === null || _b === void 0 ? void 0 : _b.characteristics.get(characteristicKey(uuid, instance))) === null || _c === void 0 ? void 0 : _c.characteristic;
-        };
-        this.addCharacteristic = (service, characteristic) => {
-            var _a;
-            const serviceRecord = (_a = __classPrivateFieldGet(this, _Store_devices, "f").get(service.device.id)) === null || _a === void 0 ? void 0 : _a.services.get(service.uuid);
-            if (!serviceRecord) {
-                throw new ReferenceError(`Service ${service.uuid} not found`);
-            }
-            serviceRecord.characteristics.set(keyForCharacteristic(characteristic), { uuid: characteristic.uuid, characteristic, descriptors: new Map() });
-        };
-        this.updateCharacteristicValue = (deviceUuid, serviceUuid, uuid, instance, value) => {
-            var _a, _b, _c;
-            const characteristic = (_c = (_b = (_a = __classPrivateFieldGet(this, _Store_devices, "f").get(deviceUuid)) === null || _a === void 0 ? void 0 : _a.services.get(serviceUuid)) === null || _b === void 0 ? void 0 : _b.characteristics.get(characteristicKey(uuid, instance))) === null || _c === void 0 ? void 0 : _c.characteristic;
-            if (!characteristic) {
-                throw new ReferenceError(`Characteristic ${uuid} not found`);
-            }
-            characteristic.value = value;
-            return characteristic;
-        };
-        this.getDescriptor = (characteristic, uuid) => {
-            var _a, _b, _c;
-            return (_c = (_b = (_a = __classPrivateFieldGet(this, _Store_devices, "f")
-                .get(characteristic.service.device.id)) === null || _a === void 0 ? void 0 : _a.services.get(characteristic.service.uuid)) === null || _b === void 0 ? void 0 : _b.characteristics.get(characteristicKey(characteristic.uuid, characteristic.instance))) === null || _c === void 0 ? void 0 : _c.descriptors.get(uuid);
-        };
-        this.addDescriptor = (characteristic, descriptor) => {
-            var _a, _b;
-            const characteristicRecord = (_b = (_a = __classPrivateFieldGet(this, _Store_devices, "f")
-                .get(characteristic.service.device.id)) === null || _a === void 0 ? void 0 : _a.services.get(characteristic.service.uuid)) === null || _b === void 0 ? void 0 : _b.characteristics.get(keyForCharacteristic(characteristic));
-            if (!characteristicRecord) {
-                throw new ReferenceError(`Characteristic ${characteristic.uuid} not found`);
-            }
-            characteristicRecord.descriptors.set(descriptor.uuid, descriptor);
-        };
-        __classPrivateFieldSet(this, _Store_devices, new Map(), "f");
+        this.#devices = new Map();
     }
+    getDevice = (uuid) => {
+        return this.#devices.get(uuid)?.device;
+    };
+    addDevice = (device) => {
+        this.removeDevice(device.id);
+        this.#devices.set(device.id, { uuid: device.id, device, services: new Map() });
+    };
+    removeDevice = (uuid) => {
+        const deviceRecord = this.#devices.get(uuid);
+        this.#devices.delete(uuid);
+        return deviceRecord?.device;
+    };
+    getService = (deviceUuid, serviceUuid) => {
+        return this.#devices.get(deviceUuid)?.services.get(serviceUuid)?.service;
+    };
+    addService = (service) => {
+        const deviceRecord = this.#devices.get(service.device.id);
+        if (!deviceRecord) {
+            throw new ReferenceError(`Device ${service.device.id} not found`);
+        }
+        deviceRecord.services.set(service.uuid, { uuid: service.uuid, service, characteristics: new Map() });
+    };
+    getCharacteristic = (service, uuid, instance) => {
+        return this.#devices.get(service.device.id)?.services.get(service.uuid)?.characteristics.get(characteristicKey(uuid, instance))?.characteristic;
+    };
+    addCharacteristic = (service, characteristic) => {
+        const serviceRecord = this.#devices.get(service.device.id)?.services.get(service.uuid);
+        if (!serviceRecord) {
+            throw new ReferenceError(`Service ${service.uuid} not found`);
+        }
+        serviceRecord.characteristics.set(keyForCharacteristic(characteristic), { uuid: characteristic.uuid, characteristic, descriptors: new Map() });
+    };
+    updateCharacteristicValue = (deviceUuid, serviceUuid, uuid, instance, value) => {
+        const characteristic = this.#devices.get(deviceUuid)?.services.get(serviceUuid)?.characteristics.get(characteristicKey(uuid, instance))?.characteristic;
+        if (!characteristic) {
+            throw new ReferenceError(`Characteristic ${uuid} not found`);
+        }
+        characteristic.value = value;
+        return characteristic;
+    };
+    getDescriptor = (characteristic, uuid) => {
+        return this.#devices
+            .get(characteristic.service.device.id)
+            ?.services
+            .get(characteristic.service.uuid)
+            ?.characteristics
+            .get(characteristicKey(characteristic.uuid, characteristic.instance))
+            ?.descriptors
+            .get(uuid);
+    };
+    addDescriptor = (characteristic, descriptor) => {
+        const characteristicRecord = this.#devices
+            .get(characteristic.service.device.id)
+            ?.services
+            .get(characteristic.service.uuid)
+            ?.characteristics
+            .get(keyForCharacteristic(characteristic));
+        if (!characteristicRecord) {
+            throw new ReferenceError(`Characteristic ${characteristic.uuid} not found`);
+        }
+        characteristicRecord.descriptors.set(descriptor.uuid, descriptor);
+    };
 }
-_Store_devices = new WeakMap();
 const store = new Store();
 
 const getOrCreateDescriptor = (characteristic, uuid) => {
@@ -494,81 +537,106 @@ const getOrCreateDescriptor = (characteristic, uuid) => {
     store.addDescriptor(characteristic, descriptor);
     return descriptor;
 };
+// https://developer.mozilla.org/en-US/docs/Web/API/BluetoothRemoteGATTCharacteristic
 class BluetoothRemoteGATTCharacteristic extends EventTarget {
+    service;
+    uuid;
+    properties;
+    instance;
+    // https://developer.mozilla.org/en-US/docs/Web/API/BluetoothRemoteGATTCharacteristic/value
+    value;
     constructor(service, uuid, properties, instance) {
         super();
         this.service = service;
         this.uuid = uuid;
         this.properties = properties;
         this.instance = instance;
-        this.GetGATTChildren = async (single, descriptor) => {
-            const response = await bluetoothRequest('discoverDescriptors', {
-                device: this.service.device.id,
-                service: this.service.uuid,
-                characteristic: this.uuid,
-                instance: this.instance,
-                descriptor: descriptor ? BluetoothUUID.getDescriptor(descriptor) : null,
-                single: single
-            });
-            return response.map(uuid => getOrCreateDescriptor(this, uuid));
-        };
-        this.getDescriptor = async (descriptor) => {
-            if (typeof descriptor === "undefined") {
-                throw new TypeError("Missing 'descriptor' UUID parameter.");
-            }
-            const descriptors = await this.GetGATTChildren(true, descriptor);
-            return descriptors[0];
-        };
-        this.getDescriptors = async (descriptor) => {
-            return this.GetGATTChildren(false, descriptor);
-        };
-        this.readValue = async () => {
-            await bluetoothRequest('readCharacteristic', {
-                device: this.service.device.id,
-                service: this.service.uuid,
-                characteristic: this.uuid,
-                instance: this.instance
-            });
-            return copyOf(this.value);
-        };
-        this.startNotifications = async () => {
-            await bluetoothRequest('startNotifications', {
-                device: this.service.device.id,
-                service: this.service.uuid,
-                characteristic: this.uuid,
-                instance: this.instance
-            });
-            return this;
-        };
-        this.stopNotifications = async () => {
-            await bluetoothRequest('stopNotifications', {
-                device: this.service.device.id,
-                service: this.service.uuid,
-                characteristic: this.uuid,
-                instance: this.instance
-            });
-            return this;
-        };
-        this._writeValue = async (value, withResponse) => {
-            const arrayBuffer = isView(value) ? value.buffer : value;
-            const base64 = arrayBufferToBase64(arrayBuffer);
-            await bluetoothRequest('writeCharacteristic', {
-                device: this.service.device.id,
-                service: this.service.uuid,
-                characteristic: this.uuid,
-                instance: this.instance,
-                value: base64,
-                withResponse: withResponse
-            });
-        };
-        this.writeValueWithResponse = async (value) => {
-            return this._writeValue(value, true);
-        };
-        this.writeValueWithoutResponse = async (value) => {
-            return this._writeValue(value, false);
-        };
         this.value = null;
     }
+    /**
+     * Loosely models the `GetGATTChildren` function as described in the Web Bluetooth Specification:
+     * https://webbluetoothcg.github.io/web-bluetooth/#bluetoothgattcharacteristic-interface
+     *
+     * ```
+     * Return GetGATTChildren(attribute=this,
+     *                        single=<boolean>,
+     *                        uuidCanonicalizer=BluetoothUUID.getCharacteristic,
+     *                        uuid=descriptor,
+     *                        allowedUuids=undefined,
+     *                        child type="GATT Descriptor")
+     * ```
+     */
+    GetGATTChildren = async (single, descriptor) => {
+        const response = await bluetoothRequest('discoverDescriptors', {
+            device: this.service.device.id,
+            service: this.service.uuid,
+            characteristic: this.uuid,
+            instance: this.instance,
+            descriptor: descriptor ? BluetoothUUID.getDescriptor(descriptor) : null,
+            single: single
+        });
+        return response.map(uuid => getOrCreateDescriptor(this, uuid));
+    };
+    // https://developer.mozilla.org/en-US/docs/Web/API/BluetoothRemoteGATTCharacteristic/getDescriptor
+    getDescriptor = async (descriptor) => {
+        if (typeof descriptor === "undefined") {
+            throw new TypeError("Missing 'descriptor' UUID parameter.");
+        }
+        const descriptors = await this.GetGATTChildren(true, descriptor);
+        return descriptors[0];
+    };
+    // https://developer.mozilla.org/en-US/docs/Web/API/BluetoothRemoteGATTCharacteristic/getDescriptors
+    getDescriptors = async (descriptor) => {
+        return this.GetGATTChildren(false, descriptor);
+    };
+    // https://developer.mozilla.org/en-US/docs/Web/API/BluetoothRemoteGATTCharacteristic/readValue
+    readValue = async () => {
+        await bluetoothRequest('readCharacteristic', {
+            device: this.service.device.id,
+            service: this.service.uuid,
+            characteristic: this.uuid,
+            instance: this.instance
+        });
+        return copyOf(this.value);
+    };
+    startNotifications = async () => {
+        await bluetoothRequest('startNotifications', {
+            device: this.service.device.id,
+            service: this.service.uuid,
+            characteristic: this.uuid,
+            instance: this.instance
+        });
+        return this;
+    };
+    stopNotifications = async () => {
+        await bluetoothRequest('stopNotifications', {
+            device: this.service.device.id,
+            service: this.service.uuid,
+            characteristic: this.uuid,
+            instance: this.instance
+        });
+        return this;
+    };
+    _writeValue = async (value, withResponse) => {
+        const arrayBuffer = isView(value) ? value.buffer : value;
+        const base64 = arrayBufferToBase64(arrayBuffer);
+        await bluetoothRequest('writeCharacteristic', {
+            device: this.service.device.id,
+            service: this.service.uuid,
+            characteristic: this.uuid,
+            instance: this.instance,
+            value: base64,
+            withResponse: withResponse
+        });
+    };
+    // https://developer.mozilla.org/en-US/docs/Web/API/BluetoothRemoteGATTCharacteristic/writeValueWithResponse
+    writeValueWithResponse = async (value) => {
+        return this._writeValue(value, true);
+    };
+    // https://developer.mozilla.org/en-US/docs/Web/API/BluetoothRemoteGATTCharacteristic/writeValueWithoutResponse
+    writeValueWithoutResponse = async (value) => {
+        return this._writeValue(value, false);
+    };
 }
 const isView = (source) => source.buffer !== undefined;
 
@@ -581,32 +649,51 @@ const getOrCreateCharacteristic = (service, uuid, properties, instance) => {
     store.addCharacteristic(service, characteristic);
     return characteristic;
 };
+// https://developer.mozilla.org/en-US/docs/Web/API/BluetoothRemoteGATTService
 class BluetoothRemoteGATTService extends EventTarget {
+    device;
+    uuid;
+    isPrimary;
     constructor(device, uuid, isPrimary) {
         super();
-        this.GetGATTChildren = async (single, characteristic) => {
-            const response = await bluetoothRequest('discoverCharacteristics', {
-                device: this.device.id,
-                service: this.uuid,
-                characteristic: characteristic ? BluetoothUUID.getCharacteristic(characteristic) : null,
-                single: single
-            });
-            return response.characteristics.map(characteristic => getOrCreateCharacteristic(this, characteristic.uuid, characteristic.properties, characteristic.instance));
-        };
-        this.getCharacteristic = async (characteristic) => {
-            if (typeof characteristic === "undefined") {
-                throw new TypeError("Missing 'characteristic' UUID parameter.");
-            }
-            const characteristics = await this.GetGATTChildren(true, characteristic);
-            return characteristics[0];
-        };
-        this.getCharacteristics = async (characteristic) => {
-            return this.GetGATTChildren(false, characteristic);
-        };
         this.device = device;
         this.uuid = uuid;
         this.isPrimary = isPrimary;
     }
+    /**
+     * Loosely models the `GetGATTChildren` function as described in the Web Bluetooth Specification:
+     * https://webbluetoothcg.github.io/web-bluetooth/#bluetoothgattservice-interface
+     *
+     * ```
+     * Return GetGATTChildren(attribute=this,
+     *                        single=<boolean>,
+     *                        uuidCanonicalizer=BluetoothUUID.getCharacteristic,
+     *                        uuid=characteristic,
+     *                        allowedUuids=undefined,
+     *                        child type="GATT Characteristic")
+     * ```
+     */
+    GetGATTChildren = async (single, characteristic) => {
+        const response = await bluetoothRequest('discoverCharacteristics', {
+            device: this.device.id,
+            service: this.uuid,
+            characteristic: characteristic ? BluetoothUUID.getCharacteristic(characteristic) : null,
+            single: single
+        });
+        return response.characteristics.map(characteristic => getOrCreateCharacteristic(this, characteristic.uuid, characteristic.properties, characteristic.instance));
+    };
+    // https://developer.mozilla.org/en-US/docs/Web/API/BluetoothRemoteGATTService/getCharacteristic
+    getCharacteristic = async (characteristic) => {
+        if (typeof characteristic === "undefined") {
+            throw new TypeError("Missing 'characteristic' UUID parameter.");
+        }
+        const characteristics = await this.GetGATTChildren(true, characteristic);
+        return characteristics[0];
+    };
+    // https://developer.mozilla.org/en-US/docs/Web/API/BluetoothRemoteGATTService/getCharacteristics
+    getCharacteristics = async (characteristic) => {
+        return this.GetGATTChildren(false, characteristic);
+    };
 }
 
 const getOrCreateService = (device, uuid, isPrimary) => {
@@ -618,73 +705,105 @@ const getOrCreateService = (device, uuid, isPrimary) => {
     store.addService(service);
     return service;
 };
+// https://developer.mozilla.org/en-US/docs/Web/API/BluetoothRemoteGATTServer
 class BluetoothRemoteGATTServer {
+    device;
+    connected;
     constructor(device) {
-        this.connect = async () => {
-            const response = await bluetoothRequest('connect', { uuid: this.device.id });
-            this.connected = response.connected;
-            return this;
-        };
-        this.disconnect = async () => {
-            const response = await bluetoothRequest('disconnect', { uuid: this.device.id });
-            this.connected = !response.disconnected;
-        };
-        this.GetGATTChildren = async (single, service) => {
-            const response = await bluetoothRequest('discoverServices', {
-                device: this.device.id,
-                service: service ? BluetoothUUID.getService(service) : null,
-                single: single
-            });
-            return response.services.map(service => getOrCreateService(this.device, service, true));
-        };
-        this.getPrimaryService = async (bluetoothServiceUUID) => {
-            if (typeof bluetoothServiceUUID === "undefined") {
-                throw new TypeError("Missing 'bluetoothServiceUUID' parameter.");
-            }
-            const services = await this.GetGATTChildren(true, bluetoothServiceUUID);
-            return services[0];
-        };
-        this.getPrimaryServices = async (bluetoothServiceUUID) => {
-            return this.GetGATTChildren(false, bluetoothServiceUUID);
-        };
         this.device = device;
         this.connected = false;
     }
+    connect = async () => {
+        const response = await bluetoothRequest('connect', { uuid: this.device.id });
+        this.connected = response.connected;
+        return this;
+    };
+    disconnect = async () => {
+        const response = await bluetoothRequest('disconnect', { uuid: this.device.id });
+        this.connected = !response.disconnected;
+    };
+    /**
+     * Loosely models the `GetGATTChildren` function as described in the Web Bluetooth Specification:
+     * https://webbluetoothcg.github.io/web-bluetooth/#bluetoothgattremoteserver-interface
+     *
+     * ```
+     * Return GetGATTChildren(attribute=this.device,
+     *                        single=<boolean>,
+     *                        uuidCanonicalizer=BluetoothUUID.getService,
+     *                        uuid=service,
+     *                        allowedUuids=this.device.[[allowedServices]],
+     *                        child type="GATT Primary Service")
+     * ```
+     */
+    GetGATTChildren = async (single, service) => {
+        const response = await bluetoothRequest('discoverServices', {
+            device: this.device.id,
+            service: service ? BluetoothUUID.getService(service) : null,
+            single: single
+        });
+        return response.services.map(service => getOrCreateService(this.device, service, true));
+    };
+    // https://developer.mozilla.org/en-US/docs/Web/API/BluetoothRemoteGATTServer/getPrimaryService
+    getPrimaryService = async (bluetoothServiceUUID) => {
+        if (typeof bluetoothServiceUUID === "undefined") {
+            throw new TypeError("Missing 'bluetoothServiceUUID' parameter.");
+        }
+        const services = await this.GetGATTChildren(true, bluetoothServiceUUID);
+        return services[0];
+    };
+    // https://developer.mozilla.org/en-US/docs/Web/API/BluetoothRemoteGATTServer/getPrimaryServices
+    getPrimaryServices = async (bluetoothServiceUUID) => {
+        return this.GetGATTChildren(false, bluetoothServiceUUID);
+    };
 }
 
+// https://developer.mozilla.org/en-US/docs/Web/API/BluetoothDevice
 class BluetoothDevice extends EventTarget {
+    id;
+    name;
+    gatt;
+    watchingAdvertisements;
     constructor(id, name) {
         super();
-        this.forget = async () => {
-            await bluetoothRequest('forgetDevice', { uuid: this.id });
-            store.removeDevice(this.id);
-        };
-        this.watchAdvertisements = async (options) => {
-            let signal = options === null || options === void 0 ? void 0 : options.signal;
-            if (signal) {
-                if (signal.aborted) {
-                    await this._toggleWatchingAdvertisements(false);
-                    return;
-                }
-                signal.addEventListener('abort', () => {
-                    this._toggleWatchingAdvertisements(false);
-                });
-            }
-            if (!this.watchingAdvertisements) {
-                await this._toggleWatchingAdvertisements(true);
-            }
-        };
-        this._toggleWatchingAdvertisements = async (isWatching) => {
-            await bluetoothRequest('watchAdvertisements', { uuid: this.id, enable: isWatching });
-            this.watchingAdvertisements = isWatching;
-        };
         this.id = id;
         this.name = name;
         this.gatt = new BluetoothRemoteGATTServer(this);
         this.watchingAdvertisements = false;
     }
+    // TODO: https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes
+    // Events:
+    // advertisementreceived
+    // gattserverdisconnected
+    // characteristicvaluechanged
+    // serviceadded
+    // servicechanged
+    // serviceremoved
+    forget = async () => {
+        await bluetoothRequest('forgetDevice', { uuid: this.id });
+        store.removeDevice(this.id);
+    };
+    watchAdvertisements = async (options) => {
+        let signal = options?.signal;
+        if (signal) {
+            if (signal.aborted) {
+                await this._toggleWatchingAdvertisements(false);
+                return;
+            }
+            signal.addEventListener('abort', () => {
+                this._toggleWatchingAdvertisements(false);
+            });
+        }
+        if (!this.watchingAdvertisements) {
+            await this._toggleWatchingAdvertisements(true);
+        }
+    };
+    _toggleWatchingAdvertisements = async (isWatching) => {
+        await bluetoothRequest('watchAdvertisements', { uuid: this.id, enable: isWatching });
+        this.watchingAdvertisements = isWatching;
+    };
 }
 
+// https://webbluetoothcg.github.io/web-bluetooth/#device-discovery
 const addToActiveScans = (scan) => {
     const bluetooth = globalThis.topaz.bluetooth;
     removeFromActiveScans(scan.scanId);
@@ -694,23 +813,31 @@ const removeFromActiveScans = (scanId) => {
     const bluetooth = globalThis.topaz.bluetooth;
     bluetooth.activeScans = bluetooth.activeScans.filter((s) => s.scanId !== scanId);
 };
+// https://webbluetoothcg.github.io/web-bluetooth/scanning.html#bluetoothlescan
 class BluetoothLEScan {
+    scanId;
+    filters;
+    keepRepeatedDevices;
+    acceptAllAdvertisements;
+    active;
     constructor(scanId, filters, keepRepeatedDevices, acceptAllAdvertisements, active) {
         this.scanId = scanId;
         this.filters = filters;
         this.keepRepeatedDevices = keepRepeatedDevices;
         this.acceptAllAdvertisements = acceptAllAdvertisements;
         this.active = active;
-        this.stop = () => {
-            this.active = false;
-            removeFromActiveScans(this.scanId);
-            bluetoothRequest('requestLEScan', { scanId: this.scanId, stop: true });
-        };
     }
+    stop = () => {
+        this.active = false;
+        removeFromActiveScans(this.scanId);
+        bluetoothRequest('requestLEScan', { scanId: this.scanId, stop: true });
+    };
 }
+// https://webbluetoothcg.github.io/web-bluetooth/scanning.html#scanning
 const doRequestLEScan = async (options) => {
     const response = await bluetoothRequest('requestLEScan', { options: options });
-    const newScan = new BluetoothLEScan(response.scanId, options.filters, response.keepRepeatedDevices, response.acceptAllAdvertisements, response.active);
+    const newScan = new BluetoothLEScan(response.scanId, options.filters, // Note: Passing through the input filters as a shortcut here
+    response.keepRepeatedDevices, response.acceptAllAdvertisements, response.active);
     addToActiveScans(newScan);
     return newScan;
 };
@@ -724,31 +851,42 @@ const getOrCreateDevice = (uuid, name) => {
     store.addDevice(device);
     return device;
 };
+// https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth
 class Bluetooth extends EventTarget {
+    activeScans = [];
     constructor() {
         super();
-        this.activeScans = [];
-        this.getAvailability = async () => {
-            const response = await bluetoothRequest('getAvailability');
-            return response.isAvailable;
-        };
-        this.getDevices = async () => {
-            const response = await bluetoothRequest('getDevices');
-            return response.map(device => getOrCreateDevice(device.uuid, device.name));
-        };
-        this.requestDevice = async (options) => {
-            const response = await bluetoothRequest('requestDevice', { options: options });
-            return getOrCreateDevice(response.uuid, response.name);
-        };
-        this.requestLEScan = async (options) => {
-            return doRequestLEScan(options);
-        };
     }
+    // TODO: https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes
+    // Events: advertisementreceived
+    getAvailability = async () => {
+        const response = await bluetoothRequest('getAvailability');
+        return response.isAvailable;
+    };
+    getDevices = async () => {
+        const response = await bluetoothRequest('getDevices');
+        return response.map(device => getOrCreateDevice(device.uuid, device.name));
+    };
+    requestDevice = async (options) => {
+        const response = await bluetoothRequest('requestDevice', { options: options });
+        return getOrCreateDevice(response.uuid, response.name);
+    };
+    requestLEScan = async (options) => {
+        return doRequestLEScan(options);
+    };
 }
 
+// https://webbluetoothcg.github.io/web-bluetooth/#advertising-events
 class BluetoothAdvertisingEvent extends Event {
+    device;
+    uuids;
+    name;
+    appearance;
+    txPower;
+    rssi;
+    manufacturerData;
+    serviceData;
     constructor(type, eventInitDict) {
-        var _a, _b;
         super(type, eventInitDict);
         this.device = eventInitDict.device;
         this.uuids = eventInitDict.uuids;
@@ -756,10 +894,12 @@ class BluetoothAdvertisingEvent extends Event {
         this.appearance = eventInitDict.appearance;
         this.txPower = eventInitDict.txPower;
         this.rssi = eventInitDict.rssi;
-        this.manufacturerData = (_a = eventInitDict.manufacturerData) !== null && _a !== void 0 ? _a : new Map();
-        this.serviceData = (_b = eventInitDict.serviceData) !== null && _b !== void 0 ? _b : new Map();
+        this.manufacturerData = eventInitDict.manufacturerData ?? new Map();
+        this.serviceData = eventInitDict.serviceData ?? new Map();
     }
 }
+// Assumes event.name === 'advertisementreceived'
+// Side effect: creates a new device if it doesn't exist and adds it to the store
 const convertToAdvertisingEvent = (event) => {
     const payload = event.data;
     const device = getOrCreateDevice(payload.device.uuid, payload.device.name);
@@ -782,13 +922,17 @@ const convertToAdvertisingEvent = (event) => {
     });
 };
 
+// https://webbluetoothcg.github.io/web-bluetooth/#valueevent
 class ValueEvent extends Event {
+    value;
     constructor(type, eventInitDict) {
         super(type, eventInitDict);
-        this.value = eventInitDict === null || eventInitDict === void 0 ? void 0 : eventInitDict.value;
+        this.value = eventInitDict?.value;
     }
 }
 
+// Assumes event.name === 'characteristicvaluechanged'
+// Side effect: updates the value property of the characteristic in the store
 const convertToCharacteristicEvent = (event) => {
     const payload = event.data;
     const data = base64ToDataView(payload.value);
@@ -800,6 +944,7 @@ const processBluetoothEvent = (event) => {
     let eventToSend;
     let targets = [];
     if (event.id === 'bluetooth') {
+        // This is the magic ID for the global Bluetooth object
         targets.push(globalThis.topaz.bluetooth);
     }
     const pushDeviceTarget = () => {
@@ -814,6 +959,7 @@ const processBluetoothEvent = (event) => {
         pushDeviceTarget();
     }
     else if (event.name === 'characteristicvaluechanged') {
+        // Decode the data payload, update the store, and forward event to the specific characteristic
         const characteristicEvent = convertToCharacteristicEvent(event);
         targets.push(characteristicEvent.characteristic);
         eventToSend = characteristicEvent.event;
@@ -823,6 +969,7 @@ const processBluetoothEvent = (event) => {
         pushDeviceTarget();
     }
     if (!eventToSend) {
+        // The default is a ValueEvent with the raw data payload
         eventToSend = new ValueEvent(event.name, { value: event.data });
     }
     return { event: eventToSend, targets: targets };
@@ -849,6 +996,7 @@ const processEvent = (event) => {
     }
     for (const target of dispatch.targets) {
         target.dispatchEvent(dispatch.event);
+        // Invoke the on<event> handler if it exists
         const handler = target['on' + dispatch.event.type];
         if (handler) {
             handler(dispatch.event);
@@ -864,6 +1012,8 @@ const safeStringify = (obj) => {
         return `Cannot stringify object ${e.message}`;
     }
 };
+// TODO: Some more work to do here to implement the full-spec properly:
+// https://console.spec.whatwg.org/#formatting-specifiers
 const percentInterpolation = (format, args) => {
     if (typeof (format) !== 'string') {
         return;
@@ -943,7 +1093,11 @@ const setupLogging = () => {
     });
 };
 
+// Polyfill for https://developer.mozilla.org/en-US/docs/Web/API/VirtualKeyboard
+// https://www.w3.org/TR/virtual-keyboard/#the-virtualkeyboard-interface
 class VirtualKeyboard extends EventTarget {
+    _boundingRect;
+    _overlaysContent;
     get boundingRect() {
         return this._boundingRect;
     }
@@ -956,30 +1110,35 @@ class VirtualKeyboard extends EventTarget {
     }
     constructor() {
         super();
-        this.show = () => {
-            virtualKeyboardRequest('show', { show: true });
-            console.warn('VirtualKeyboard.show() is not supported by this browser.');
-        };
-        this.hide = () => {
-            virtualKeyboardRequest('show', { show: false });
-            console.warn('VirtualKeyboard.hide() is not supported by this browser.');
-        };
-        this._updateBoundingRect = (data) => {
-            this._boundingRect = new DOMRect(data.x, data.y, data.width, data.height);
-        };
         this._boundingRect = new DOMRect(0, 0, 0, 0);
         this._overlaysContent = false;
     }
+    show = () => {
+        virtualKeyboardRequest('show', { show: true });
+        console.warn('VirtualKeyboard.show() is not supported by this browser.');
+    };
+    hide = () => {
+        virtualKeyboardRequest('show', { show: false });
+        console.warn('VirtualKeyboard.hide() is not supported by this browser.');
+    };
+    _updateBoundingRect = (data) => {
+        this._boundingRect = new DOMRect(data.x, data.y, data.width, data.height);
+    };
 }
 
 class Topaz {
+    bluetooth;
+    virtualKeyboard;
     constructor() {
-        this.sendEvent = (event) => {
-            processEvent(event);
-        };
         this.bluetooth = new Bluetooth();
         this.virtualKeyboard = new VirtualKeyboard();
     }
+    sendEvent = (event) => {
+        processEvent(event);
+    };
+    setUserAgentMode = async (mode) => {
+        await topazRequest("setUserAgentMode", { mode });
+    };
 }
 const ensureInitialized = () => {
     if (globalThis.topaz === undefined) {
@@ -988,6 +1147,7 @@ const ensureInitialized = () => {
     }
 };
 
+// Polyfill for https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth
 if (typeof (navigator.bluetooth) === 'undefined') {
     ensureInitialized();
     navigator.bluetooth = globalThis.topaz.bluetooth;

--- a/lib/Sources/WebView/WebPageModel.swift
+++ b/lib/Sources/WebView/WebPageModel.swift
@@ -33,8 +33,24 @@ public class WebPageModel: Identifiable {
 
     let messageProcessorFactory: JsMessageProcessorFactory
 
+    enum UserAgentMode: String {
+        case topaz
+        case safari
+    }
+
     // TODO: dynamically construct this
-    let customUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Version/3.9.0 Topaz/3.9.0"
+    private let topazUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Version/3.9.0 Topaz/3.9.0"
+    private let safariUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Version/26.0 Safari/605.1.15"
+    private(set) var userAgentMode: UserAgentMode = .topaz
+
+    var customUserAgent: String {
+        switch userAgentMode {
+        case .topaz:
+            topazUserAgent
+        case .safari:
+            safariUserAgent
+        }
+    }
 
     public var hostname: String {
         url.host(percentEncoded: false) ?? "unknown"
@@ -59,6 +75,10 @@ public class WebPageModel: Identifiable {
 
     public func loadNewPage(url: URL) {
         self.url = url
+    }
+
+    func setUserAgentMode(_ mode: UserAgentMode) {
+        userAgentMode = mode
     }
 
     func createWebView() -> WKWebView {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Any page can change the reported user agent mid-session, which can alter server routing, feature flags, and compatibility behavior; the bridge is narrow but not origin-restricted in this diff.
> 
> **Overview**
> Adds **`topaz.setUserAgentMode('topaz' | 'safari')`** so loaded pages can switch the WebView user agent at runtime, mainly to present a Safari-like UA when sites gate on it.
> 
> The flow is a new **`topaz`** WebKit JS message channel (`topazRequest` in TS and the injected polyfill) handled by **`TopazScriptHandler`** in `Coordinator`, which updates **`WebPageModel.userAgentMode`** and applies **`WKWebView.customUserAgent`**. **`WebPageModel`** now picks between fixed Topaz and Safari UA strings (default remains Topaz). **`Coordinator.update`** also reapplies the model’s UA when the web view updates.
> 
> The large **`BluetoothPolyfill.js`** diff is mostly a rebuild (e.g. `topazRequest`, class field style, docs); behavior changes there are incidental to shipping the new Topaz API in the bundle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ca839f6b12ea17b2488eceeea453763f77994d4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->