### PR TITLE
CA-6346: Change minimum iOS version to 18.

### DIFF
--- a/lib/Package.swift
+++ b/lib/Package.swift
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
     name: "App",
     platforms: [
-        .iOS(.v17),
-        .macOS(.v14),
+        .iOS(.v18),
+        .macOS(.v15),
     ],
     products: [
         .library(name: "App", targets: ["App"]),

--- a/topaz.xcodeproj/project.pbxproj
+++ b/topaz.xcodeproj/project.pbxproj
@@ -445,7 +445,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -475,7 +475,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Drops support for iOS 17.x users and may require aligned bumps in CI, TestFlight, and App Store metadata; runtime behavior is unchanged.
> 
> **Overview**
> Raises the **Topaz** app’s minimum supported iOS version from **17.6** to **18.0** by updating `IPHONEOS_DEPLOYMENT_TARGET` in the **Debug** and **Release** build configurations in `topaz.xcodeproj/project.pbxproj`.
> 
> Devices on iOS 17.x will no longer be able to install or run new builds; there are no Swift or feature changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db5d43f14ea8833d2172e66dacb7a326fedc99cf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->