### PR TITLE
CA-6181: Workaround Keyboard toolbar redraw issue

### DIFF
--- a/lib/Sources/WebView/WebPageModel.swift
+++ b/lib/Sources/WebView/WebPageModel.swift
@@ -13,7 +13,7 @@ import WebKit
 // shows up for WebView TextFields. This isn't ideal--especially for websites that are expecting
 // a toolbar for ease of UI use--but hopefully the issue will be fixed in an upcoming SwiftUI update.
 private class NoKeyboardToolbarWebView: WKWebView {
-    
+
     override var inputAccessoryView: UIView? {
         return nil // Hides the default accessory toolbar
     }

--- a/lib/Sources/WebView/WebPageModel.swift
+++ b/lib/Sources/WebView/WebPageModel.swift
@@ -7,6 +7,18 @@ import SwiftUI
 import VirtualKeyboard
 import WebKit
 
+// This is a workaround for an iOS issue that occurs with the view layout not being properly
+// redrawn when keyboard focus on a WebView TextField that has a tool bar shifts to a
+// native app TextField with no toolbar. This workaround removes the default toolbar that
+// shows up for WebView TextFields. This isn't ideal--especially for websites that are expecting
+// a toolbar for ease of UI use--but hopefully the issue will be fixed in an upcoming SwiftUI update.
+private class NoKeyboardToolbarWebView: WKWebView {
+    
+    override var inputAccessoryView: UIView? {
+        return nil // Hides the default accessory toolbar
+    }
+}
+
 @MainActor
 @Observable
 public class WebPageModel: Identifiable {
@@ -62,7 +74,7 @@ public class WebPageModel: Identifiable {
     }
 
     func createWebView() -> WKWebView {
-        let webView = WKWebView(frame: .zero, configuration: config)
+        let webView = NoKeyboardToolbarWebView(frame: .zero, configuration: config)
         webView.allowsBackForwardNavigationGestures = true
         scrollObserver.observe(webView: webView)
         return webView


### PR DESCRIPTION
Closes #246 

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Affects all in-app web text input UX by removing the system keyboard accessory bar; behavior change is intentional but may surprise sites that rely on that toolbar.
> 
> **Overview**
> Adds a **workaround for an iOS SwiftUI layout bug** when keyboard focus moves from a WebView text field (with the default accessory toolbar) to a native app text field without one.
> 
> `WebPageModel` now builds pages with a private `NoKeyboardToolbarWebView` subclass that overrides `inputAccessoryView` to return `nil`, instead of a stock `WKWebView`. That removes the WebView keyboard toolbar so the transition no longer leaves the layout stuck, at the cost of **no default Done/arrow toolbar on web inputs** until a future platform fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b223c574743ab25dfbd520be406633cd4a02288. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->