### PR TITLE
Await cross-origin context swap in navigation policy decision

### DIFF
--- a/lib/Sources/Navigation/NavigationEngine+WKNavigationDelegate.swift
+++ b/lib/Sources/Navigation/NavigationEngine+WKNavigationDelegate.swift
@@ -28,8 +28,12 @@ extension NavigationEngine: WKNavigationDelegate {
         log.debug("Request allowed url=\(navigationAction.request.url?.absoluteString ?? "nil") isDownload=\(newRequest.isDownload) action=\(navigationAction)")
         if newRequest.isDownload {
             rememberRecentDownload(newRequest.url)
+            return .download
         }
-        return newRequest.isDownload ? .download : .allow
+        // Prepare the JS context while WebKit awaits this decision so handlers are registered
+        // before the page begins loading.
+        await delegate?.prepareContext(for: newRequest, in: webView)
+        return .allow
     }
 
     public func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse) async -> WKNavigationResponsePolicy {
@@ -65,7 +69,6 @@ extension NavigationEngine: WKNavigationDelegate {
             let navigationItem = NavigationItem(navigation: navigation, request: request)
             navigations[navigation] = navigationItem
             navigator.startObservingLoadingProgress(of: webView)
-            delegate?.didInitiateNavigation(navigationItem, in: webView)
         } else {
             log.warning("Unexpected provisional navigation ignored navigation=\(navigation)")
         }

--- a/lib/Sources/Navigation/NavigationEngineDelegate.swift
+++ b/lib/Sources/Navigation/NavigationEngineDelegate.swift
@@ -3,7 +3,7 @@ import WebKit
 
 @MainActor
 public protocol NavigationEngineDelegate: AnyObject {
-    func didInitiateNavigation(_ navigation: NavigationItem, in webView: WKWebView)
+    func prepareContext(for request: NavigationRequest, in webView: WKWebView) async
     func didBeginLoading(_ navigation: NavigationItem, in webView: WKWebView)
     func didEndLoading(_ navigation: NavigationItem, in webView: WKWebView)
     func startedDownload(for url: URL)

--- a/lib/Sources/Navigation/NavigationRequest.swift
+++ b/lib/Sources/Navigation/NavigationRequest.swift
@@ -11,12 +11,14 @@ public struct NavigationRequest {
     public let kind: NavigationKind
     public let actionType: WKNavigationType
     public let isDownload: Bool
+    public let isMainFrame: Bool
 
-    init(url: URL, kind: NavigationKind, actionType: WKNavigationType, isDownload: Bool) {
+    init(url: URL, kind: NavigationKind, actionType: WKNavigationType, isDownload: Bool, isMainFrame: Bool) {
         self.url = url
         self.kind = kind
         self.actionType = actionType
         self.isDownload = isDownload
+        self.isMainFrame = isMainFrame
     }
 
     public init?(action: WKNavigationAction) {
@@ -33,9 +35,11 @@ public struct NavigationRequest {
                 // Here we deny opening a new window unless requested from the main frame
                 return nil
             }
+            self.isMainFrame = false
             self.kind = .newWindow
             return
         }
+        self.isMainFrame = targetFrame.isMainFrame
         guard let host = url.host(percentEncoded: false), host == targetFrame.securityOrigin.host else {
             self.kind = .crossOrigin
             return
@@ -49,7 +53,7 @@ public struct NavigationRequest {
 
     func updated(with navigationResponse: WKNavigationResponse) -> Self {
         if !isDownload && navigationResponse.shouldDownload() {
-            return Self(url: url, kind: kind, actionType: actionType, isDownload: true)
+            return Self(url: url, kind: kind, actionType: actionType, isDownload: true, isMainFrame: isMainFrame)
         }
         return self
     }

--- a/lib/Sources/WebView/Coordinator.swift
+++ b/lib/Sources/WebView/Coordinator.swift
@@ -15,10 +15,6 @@ public class Coordinator: NSObject, NavigationEngineDelegate {
     private var navigationEngine: NavigationEngine?
     private var authorize: () async -> Bool = { false }
 
-    /// Serializes cross-origin context swaps. Each swap chains off the previous one so that
-    /// detach/attach pairs cannot interleave or finish out of order across rapid navigations.
-    private var pendingContextSwap: Task<Void, Never>?
-
     override init() {}
 
     func initialize(webView: WKWebView, model: WebPageModel) {
@@ -39,8 +35,6 @@ public class Coordinator: NSObject, NavigationEngineDelegate {
     }
 
     func deinitialize(webView: WKWebView) {
-        pendingContextSwap?.cancel()
-        pendingContextSwap = nil
         viewModel?.navigator.stopObservingNavigationState()
         navigationEngine = nil
         webView.navigationDelegate = nil
@@ -79,8 +73,8 @@ public class Coordinator: NSObject, NavigationEngineDelegate {
 
     // MARK: - NavigationEngineDelegate
 
-    public func didInitiateNavigation(_ navigation: NavigationItem, in webView: WKWebView) {
-        switch navigation.request.kind {
+    public func prepareContext(for request: NavigationRequest, in webView: WKWebView) async {
+        switch request.kind {
         case .newWindow:
             // Will trigger load of an entire new tab container so no need for any action
             break
@@ -88,21 +82,23 @@ public class Coordinator: NSObject, NavigationEngineDelegate {
             // Carry over the same Js context to keep BLE connections alive
             break
         case .crossOrigin:
-            // Tear down and spin up a new Js context for this new web page.
-            // Chain off any in-flight swap so detach/attach pairs stay ordered, and supersede it
-            // so a stale navigation can't attach a context after a newer one has started.
-            // TODO: move this to be synchronous work on decidePolicyFor:navigationAction instead
-            let newContextId = contextId.withUrl(navigation.request.url)
-            let previousSwap = pendingContextSwap
-            previousSwap?.cancel()
-            pendingContextSwap = Task { @MainActor [weak self] in
-                _ = await previousSwap?.value
-                guard let self, !Task.isCancelled else { return }
-                await self.detachOldHandlerAndWait(from: webView)
-                guard !Task.isCancelled, self.viewModel != nil else { return }
-                self.contextId = newContextId
-                self.attachNewHandler(to: webView)
+            // Tear down the old Js context and spin up a new one for this page. WebKit awaits this
+            // call within the navigation policy decision, so the new handlers are guaranteed to be
+            // registered before the page begins loading.
+            guard request.isMainFrame else {
+                // A cross-origin sub-frame (e.g. ad/widget iframe) must not tear down the main page.
+                return
             }
+            guard request.url.host(percentEncoded: false) != contextId.url.host(percentEncoded: false) else {
+                // Redirect chains can fire this decision repeatedly; only swap when the origin
+                // actually changes to avoid thrashing the BLE teardown/attach cycle.
+                return
+            }
+            await detachOldHandlerAndWait(from: webView)
+            // The page (and this Coordinator) may have been torn down while awaiting teardown.
+            guard viewModel != nil else { return }
+            contextId = contextId.withUrl(request.url)
+            attachNewHandler(to: webView)
         }
     }
 

--- a/lib/Tests/NavigationTests/NavigationRequestTests.swift
+++ b/lib/Tests/NavigationTests/NavigationRequestTests.swift
@@ -113,6 +113,40 @@ struct NavigationRequestTests {
     }
 
     @Test
+    func initFromAction_withCrossOriginMainFrame_marksMainFrame() {
+        let origin = createSecurityOrigin(protocol: "http", host: "foo.com", port: 80)
+        let targetFrame = MockFrameInfo(
+            isMainFrame: { true },
+            request: { testRequest },
+            securityOrigin: { origin }
+        ).immortalize(in: &Self.retainBucket)
+        let action = MockAction(
+            request: { testRequest },
+            targetFrame: { targetFrame }
+        )
+        let sut = NavigationRequest(action: action)
+        #expect(sut?.kind == .crossOrigin)
+        #expect(sut?.isMainFrame == true)
+    }
+
+    @Test
+    func initFromAction_withCrossOriginSubFrame_marksNotMainFrame() {
+        let origin = createSecurityOrigin(protocol: "http", host: "foo.com", port: 80)
+        let targetFrame = MockFrameInfo(
+            isMainFrame: { false },
+            request: { testRequest },
+            securityOrigin: { origin }
+        ).immortalize(in: &Self.retainBucket)
+        let action = MockAction(
+            request: { testRequest },
+            targetFrame: { targetFrame }
+        )
+        let sut = NavigationRequest(action: action)
+        #expect(sut?.kind == .crossOrigin)
+        #expect(sut?.isMainFrame == false)
+    }
+
+    @Test
     func initFromAction_withRequestAndTargetOriginMatch_navigatesToSameOrigin() throws {
         let origin = createSecurityOrigin(protocol: "http", host: "test.com", port: 80)
         let targetFrame = MockFrameInfo(


### PR DESCRIPTION
Implements #273.

## Summary
- Relocates the cross-origin JS context teardown + re-attach from the unstructured `Task` spawned off the synchronous `didStartProvisionalNavigation` callback into the natively-`async` `webView(_:decidePolicyFor navigationAction:)`. WebKit awaits the decision before starting the load, so new handlers are guaranteed registered before the page begins loading and the cross-origin task races are gone.
- Adds an `async` delegate hook `prepareContext(for:in:)` on `NavigationEngineDelegate`; `NavigationEngine` awaits it inside the policy decision and `Coordinator` implements the swap. Removes `didInitiateNavigation` and the `pendingContextSwap` task entirely.

## Required guards (since the policy callback fires in more cases than the old site)
- **Main frame only** — adds `isMainFrame` to `NavigationRequest` and bails for cross-origin sub-frames, so an ad/widget iframe can't tear down the whole page's BLE context.
- **Skip downloads** — action-time downloads return `.download` early and never swap.
- **Redirect idempotency** — only swaps when the request host differs from the current `contextId` host, so redirect chains don't thrash BLE teardown/attach.

## Acceptance criteria
- [x] Cross-origin swap no longer uses an unstructured `Task`; teardown awaited within the async policy decision
- [x] New page handlers guaranteed registered before the page begins loading
- [x] Cross-origin iframe navigations don't tear down the main page's JS context / BLE connections
- [x] Cross-origin downloads don't tear down the current page
- [x] Redirect chains don't trigger repeated teardown/attach cycles

## Notes
A navigation that is cross-origin at action-time but only becomes a download at response-time (`Content-Disposition: attachment`) still swaps the context. This matches the prior behavior at the `didStartProvisionalNavigation` site (which also ran before the response) and is out of scope for #273.

## Test plan
- [x] `make build TARGET=WebView`
- [x] `swiftlint --strict` on changed files (0 violations)
- [x] `make NavigationTests` (added `isMainFrame` main-frame / sub-frame coverage)

Made with [Cursor](https://cursor.com)