### PR TITLE
Avoid webkit null pointer crash

### DIFF
--- a/lib/Sources/Navigation/ErrorDocument.swift
+++ b/lib/Sources/Navigation/ErrorDocument.swift
@@ -1,21 +1,21 @@
 import Foundation
 
-func genericErrorDocument(error: any Error, url: URL, reason: String?) -> SimpleHtmlDocument {
+func genericErrorDocument(error: any Error, url: URL?, reason: String?) -> SimpleHtmlDocument {
     let title = "Error \((error as NSError).code)"
     var document = titledErrorDocument(title: title, url: url, reason: reason)
     document.addElement(.p, error.localizedDescription)
     return document
 }
 
-func statusCodeErrorDocument(statusCode: Int, url: URL, reason: String?) -> SimpleHtmlDocument {
+func statusCodeErrorDocument(statusCode: Int, url: URL?, reason: String?) -> SimpleHtmlDocument {
     let title = "\(statusCode) \(HTTPURLResponse.localizedString(forStatusCode: statusCode).capitalized)"
     return titledErrorDocument(title: title, url: url, reason: reason)
 }
 
-private func titledErrorDocument(title: String, url: URL, reason: String?) -> SimpleHtmlDocument {
+private func titledErrorDocument(title: String, url: URL?, reason: String?) -> SimpleHtmlDocument {
     var document = SimpleHtmlDocument(title: title)
     document.addElement(.h1, title)
-    document.addElement(.p, "Unable to load \(url.absoluteString)")
+    document.addElement(.p, "Unable to load \(url?.absoluteString ?? "")")
     if let reason {
         document.addElement(.p, reason)
     }

--- a/lib/Sources/Navigation/NavigationEngine+WKNavigationDelegate.swift
+++ b/lib/Sources/Navigation/NavigationEngine+WKNavigationDelegate.swift
@@ -59,7 +59,11 @@ extension NavigationEngine: WKNavigationDelegate {
     // MARK: - Navigation logic
 
     // Request has been sent to the web server and we are ready to start receiving a response
-    public func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+    public func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation?) {
+        guard let navigation else {
+            log.debug("Unexpected null provisional navigation ignored")
+            return
+        }
         if let request = latestRequest {
             log.debug("Provisional navigation started url=\(request.url.absoluteString) isDownload=\(request.isDownload) navigation=\(navigation)")
             let navigationItem = NavigationItem(navigation: navigation, request: request)
@@ -72,7 +76,11 @@ extension NavigationEngine: WKNavigationDelegate {
     }
 
     // Started receiving a response and will attempt to begin parsing the HTML
-    public func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+    public func webView(_ webView: WKWebView, didCommit navigation: WKNavigation?) {
+        guard let navigation else {
+            log.debug("Unexpected null committed navigation ignored")
+            return
+        }
         guard let navigationItem = navigations[navigation] else {
             // Ignore untracked navigation - it is probably a request that was rejected in the decidePolicyFor method
             log.debug("Untracked navigation commit ignored navigation=\(navigation)")
@@ -84,7 +92,11 @@ extension NavigationEngine: WKNavigationDelegate {
     }
 
     // All data received and if DOM is not already complete it will be very soon
-    public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+    public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation?) {
+        guard let navigation else {
+            log.debug("Unexpected null final navigation ignored")
+            return
+        }
         guard let navigationItem = navigations.removeValue(forKey: navigation) else {
             // Ignore untracked navigation - it is probably a request that was rejected in the decidePolicyFor method
             log.debug("Untracked navigation finalization ignored navigation=\(navigation)")
@@ -114,20 +126,34 @@ extension NavigationEngine: WKNavigationDelegate {
 
     // MARK: - Error handling
 
-    public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: any Error) {
+    public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation?, withError error: any Error) {
         if (error as NSError).code == FrameLoadInterruptedErrorCode, let url = latestRequest?.url, isRecentDownload(url) {
             log.debug("Benign provisional navigation failure ignored due to download conversion for \(url)")
             latestRequest = nil
             return
         }
         log.debug("Provisional navigation failed navigation=\(navigation) error=\(error)")
+        let url = latestRequest?.url
         latestRequest = nil
-        handleError(error, for: navigation, in: webView)
+        if let navigation {
+            handleError(error, for: navigation, in: webView)
+        } else {
+            handleError(error, url: url, in: webView)
+        }
+        rejectionReason = nil
+        rejectionStatusCode = nil
     }
 
-    public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: any Error) {
+    public func webView(_ webView: WKWebView, didFail navigation: WKNavigation?, withError error: any Error) {
         log.debug("Navigation failed navigation=\(navigation) error=\(error)")
+        let url = latestRequest?.url
         latestRequest = nil
-        handleError(error, for: navigation, in: webView)
+        if let navigation {
+            handleError(error, for: navigation, in: webView)
+        } else {
+            handleError(error, url: url, in: webView)
+        }
+        rejectionReason = nil
+        rejectionStatusCode = nil
     }
 }

--- a/lib/Sources/Navigation/NavigationEngine.swift
+++ b/lib/Sources/Navigation/NavigationEngine.swift
@@ -22,10 +22,15 @@ public final class NavigationEngine: NSObject {
     func handleError(_ error: any Error, for navigation: WKNavigation, in webView: WKWebView) {
         guard shouldPresentErrorDocument(for: error) else { return }
         guard let item = navigations.removeValue(forKey: navigation) else { return }
+        handleError(error, url: item.request.url, in: webView)
+    }
+
+    func handleError(_ error: any Error, url: URL?, in webView: WKWebView) {
+        guard shouldPresentErrorDocument(for: error) else { return }
         let document = if let rejectionStatusCode {
-            statusCodeErrorDocument(statusCode: rejectionStatusCode, url: item.request.url, reason: rejectionReason)
+            statusCodeErrorDocument(statusCode: rejectionStatusCode, url: url, reason: rejectionReason)
         } else {
-            genericErrorDocument(error: error, url: item.request.url, reason: rejectionReason)
+            genericErrorDocument(error: error, url: url, reason: rejectionReason)
         }
         loadDocument(document, in: webView)
     }

--- a/lib/Sources/Navigation/NavigationEngine.swift
+++ b/lib/Sources/Navigation/NavigationEngine.swift
@@ -22,22 +22,26 @@ public final class NavigationEngine: NSObject {
     func handleError(_ error: any Error, for navigation: WKNavigation, in webView: WKWebView) {
         guard shouldPresentErrorDocument(for: error) else { return }
         guard let item = navigations.removeValue(forKey: navigation) else { return }
-        handleError(error, url: item.request.url, in: webView)
-    }
-
-    func handleError(_ error: any Error, url: URL?, in webView: WKWebView) {
-        guard shouldPresentErrorDocument(for: error) else { return }
-        let document = if let rejectionStatusCode {
-            statusCodeErrorDocument(statusCode: rejectionStatusCode, url: url, reason: rejectionReason)
-        } else {
-            genericErrorDocument(error: error, url: url, reason: rejectionReason)
-        }
+        let document = errorDocument(for: error, url: item.request.url)
         if item.request.isNativelyRetryable {
             // Present the error content as the response for the original URL so the web view's current
             // history entry is that URL. Tapping reload then re-fetches the original page natively.
             webView.loadSimulatedRequest(URLRequest(url: item.request.url), responseHTML: document.render())
         } else {
             loadDocument(document, in: webView)
+        }
+    }
+
+    func handleError(_ error: any Error, url: URL?, in webView: WKWebView) {
+        guard shouldPresentErrorDocument(for: error) else { return }
+        loadDocument(errorDocument(for: error, url: url), in: webView)
+    }
+
+    private func errorDocument(for error: any Error, url: URL?) -> SimpleHtmlDocument {
+        if let rejectionStatusCode {
+            statusCodeErrorDocument(statusCode: rejectionStatusCode, url: url, reason: rejectionReason)
+        } else {
+            genericErrorDocument(error: error, url: url, reason: rejectionReason)
         }
     }
 

--- a/lib/Sources/Navigation/SimpleHtmlDocument.swift
+++ b/lib/Sources/Navigation/SimpleHtmlDocument.swift
@@ -27,14 +27,14 @@ public struct SimpleHtmlDocument {
         element(tag: "html") {
             element(tag: "head") {
                 element(tag: "title") {
-                    [title]
+                    [title.htmlEscaped()]
                 }
             }
             +
             element(tag: "body") {
                 elements.flatMap { (tag, inner) in
                     element(tag: tag.rawValue) {
-                        [inner]
+                        [inner.htmlEscaped()]
                     }
                 }
             }
@@ -50,5 +50,23 @@ extension SimpleHtmlDocument {
     public func asDataUriRequest() -> URLRequest? {
         let data = Data(render().utf8).base64EncodedString()
         return URL(string: "data:text/html;base64," + data).map { URLRequest(url: $0) }
+    }
+}
+
+extension StringProtocol {
+    fileprivate func htmlEscaped() -> String {
+        var result = ""
+        result.reserveCapacity(count)
+        for character in self {
+            switch character {
+            case "&": result += "&amp;"
+            case "<": result += "&lt;"
+            case ">": result += "&gt;"
+            case "\"": result += "&quot;"
+            case "'": result += "&#39;"
+            default: result.append(character)
+            }
+        }
+        return result
     }
 }


### PR DESCRIPTION
The webkit delegate call backs are `null_unspecified` in Obj-C which Swift translated to a force unwrap syntax in the declaration. It turns out sometimes the `WKNavigation` value is null so we need to avoid the force unwrap.

Had to tweak the error page construction so also added some escaping to avoid malformed URLs from being a possible code injection path on the error page.

We've seen this crash in our own crash reports, and there is precedent from Firefox on iOS: https://openradar.appspot.com/22820815

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core WebKit navigation and error-display paths; fixes a real crash but alters when error pages appear and what URL they show when navigation is null.
> 
> **Overview**
> Fixes crashes when WebKit passes a **null `WKNavigation`** into delegate callbacks by treating navigation as optional and **bailing out early** on provisional start, commit, and finish instead of force-unwrapping.
> 
> On **provisional and committed navigation failures**, errors still show an error page when navigation is missing: the delegate routes to a new **`handleError` overload** that uses `latestRequest?.url`, and error-document helpers accept an **optional URL** (empty string when absent).
> 
> **Error HTML** now **escapes** title and body text via `htmlEscaped()` to reduce injection risk from malformed URLs or error strings. Rejection reason/status are **cleared** after handling navigation failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c170207566c9f965f3097b2a03faf6c3d1991b15. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->