### PR TITLE
Add AGENTS.md with Cursor Cloud environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Topaz
+
+Bluetooth-enabled web browser for iOS/macOS. See `README.md` for the developer tooling overview and `make help` for the full target list.
+
+## Cursor Cloud specific instructions
+
+### Platform limitation (important)
+
+This is a native **iOS/macOS app built with Xcode + SwiftUI + CoreBluetooth**. The primary developer workflows — `make build`, `make test`, `make run`, and the `*Tests` targets — all invoke `xcodebuild` against an iOS Simulator and therefore **only run on a macOS host with Xcode** (CI uses `macOS-15` runners; `.xcode-version` pins Xcode 26.2). None of these can build or run on the Linux Cloud VM. `swiftlint`/`swift format` (`make lint`) are also unavailable on Linux. Do not attempt `xcodebuild` here; there is no `xcrun`/Swift toolchain.
+
+### What CAN be worked on in the Linux Cloud VM
+
+Only the TypeScript Bluetooth polyfill under `lib/Javascript/` (Node/npm). It compiles `src/BluetoothPolyfill.ts` into the committed artifact `lib/Sources/WebView/Resources/Generated/BluetoothPolyfill.js` via rollup, driven by `make js` (production/minified) or `make js-debug` (non-minified). The compiled artifact is committed and consumed by the Swift `WebView` module, so it is NOT rebuilt during a normal app build — you only rebuild it when editing the `.ts` sources.
+
+### Known-broken JS build (typescript v7)
+
+`make js` / `make js-debug` currently **fail** in the repo's pinned dependency state. `package.json` pins `typescript: ^7.0.0`, which resolves to the new Go-based native compiler (`7.0.2`) that no longer exports the classic compiler API (`ts.ScriptTarget`, etc.). `@rollup/plugin-typescript` depends on that API, so rollup errors with `Cannot read properties of undefined (reading 'ES2015')`. This is a platform-independent dependency incompatibility (would also fail on macOS) and is NOT caught by CI — CI (`.github/workflows/ci.yml`) never runs `make js`. Rebuilding the polyfill requires either a compatible `typescript` version or a plugin that supports TS 7; treat that as a code change, not environment setup.
+
+### Notes
+
+- `make` at the repo root invokes `scripts/find_optimal_sim_uuid.sh`, which calls `xcrun` and prints `xcrun: not found` on Linux — harmless noise for the `js` targets.
+- `lib/Javascript/node_modules` is gitignored. Dependencies are installed by the startup update script (`npm ci` in `lib/Javascript`). Use `npm ci` (not `npm install`) to avoid rewriting `package-lock.json`, which a newer npm otherwise churns (drops `libc` metadata).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud VM development environment for Topaz and documents durable, non-obvious setup notes for future cloud agents in a new `AGENTS.md`.

Topaz is a native **iOS/macOS Bluetooth-enabled web browser** (Xcode + SwiftUI + CoreBluetooth). The primary workflows (`make build` / `make test` / `make run`, `swiftlint`) require macOS + Xcode and **cannot run on the Linux Cloud VM**. The only Linux-workable component is the TypeScript Web Bluetooth polyfill under `lib/Javascript/`.

## What this does

- Adds `AGENTS.md` `## Cursor Cloud specific instructions` documenting:
  - The macOS/Xcode platform limitation for the app build/test/run.
  - That only the `lib/Javascript/` polyfill is workable on Linux, and its compiled artifact is committed (not rebuilt on normal app builds).
  - A discovered, latent, platform-independent breakage: `make js` / `make js-debug` fail because `typescript@^7.0.0` (the Go-native compiler, no classic API) is incompatible with `@rollup/plugin-typescript` (`Cannot read properties of undefined (reading 'ES2015')`). CI never runs `make js`, so it isn't caught.
  - `npm ci` (not `npm install`) to avoid `package-lock.json` churn.
- Registers a minimal startup update script: guarded `npm ci --prefix lib/Javascript`.

No application source code is modified.

## Verification

- `npm ci` installs polyfill deps cleanly (0 vulnerabilities).
- Shipped artifact `BluetoothPolyfill.js` passes `node --check`.
- Hello-world: executing the shipped polyfill with browser globals stubbed installs `navigator.bluetooth`, `window.BluetoothUUID`, `navigator.virtualKeyboard`, and its real logic resolves the standard heart-rate service UUID (`0000180d-0000-1000-8000-00805f9b34fb`).

[topaz_env_setup.log](https://cursor.com/artifacts/c/art-4c21c1bf-9271-4392-922f-a99c33d351ef)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fe40794-3e7f-42fb-bd4c-c0959f744bdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fe40794-3e7f-42fb-bd4c-c0959f744bdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

