### PR TITLE
Review fixes for #298: teardown resolves pending permissions + is terminal

### DIFF
--- a/lib/Package.swift
+++ b/lib/Package.swift
@@ -224,6 +224,10 @@ let package = Package(
                 "UIHelpers",
             ]
         ),
+        .testTarget(
+            name: "SettingsTests",
+            dependencies: ["Settings", "TestHelpers"]
+        ),
 
         .target(
             name: "Tabs",

--- a/lib/Sources/App/AppModel.swift
+++ b/lib/Sources/App/AppModel.swift
@@ -169,10 +169,16 @@ public class AppModel {
     }
 
     /// System memory pressure: shed every background session (they revert to
-    /// reload-on-revisit) while leaving the pinned session untouched, so the app
-    /// degrades gracefully instead of being jetsammed wholesale.
+    /// reload-on-revisit) while leaving the displayed session untouched, so the app
+    /// degrades gracefully instead of being jetsammed wholesale. With the tab grid
+    /// showing, nothing is displayed - every session (including the still-pinned
+    /// last-viewed tab) is background and gets shed.
     func didReceiveMemoryWarning() {
-        sessions.evictAllExceptActive()
+        if activeSession == nil {
+            sessions.evictAll()
+        } else {
+            sessions.evictAllExceptActive()
+        }
     }
 
     /// Recovery path for a tab whose page state is unrecoverable - the web content

--- a/lib/Sources/App/AppModel.swift
+++ b/lib/Sources/App/AppModel.swift
@@ -127,6 +127,11 @@ public class AppModel {
     private func activate(tabIndex: Int, url: URL?) {
         lastOpenedTabIndex = tabIndex
         if let existing = sessions.session(for: tabIndex) {
+            // Opener-back is scoped to the window.open flow that installs it (right
+            // after this activation returns); any other route into a live session -
+            // the grid, restore-on-launch, opener-back itself - must not resurrect a
+            // stale closure pointing at a long-departed opener
+            existing.loadingModel.navBarModel.goBackToPriorPage = nil
             sessions.markActive(tabIndex)
             activeSession = existing
         } else {

--- a/lib/Sources/App/AppModel.swift
+++ b/lib/Sources/App/AppModel.swift
@@ -42,6 +42,12 @@ public class AppModel {
     /// tab grid - cached sessions stay alive underneath it.
     var activeSession: TabSession? {
         didSet {
+            if oldValue !== activeSession {
+                // The outgoing page must not keep the keyboard: its web view is moving
+                // to the invisible underlay (or away entirely) where a lingering first
+                // responder would float a stale keyboard over the incoming view
+                oldValue?.resignFocus()
+            }
             activeTabState.setActiveTab(activeSession?.tabIndex)
         }
     }

--- a/lib/Sources/App/AppModel.swift
+++ b/lib/Sources/App/AppModel.swift
@@ -256,8 +256,21 @@ public class AppModel {
         loadingModel.freshPageModel.searchBarFocusOnLoad = false
         loadingModel.navBarModel.searchBarModel.searchString = url.absoluteString
         Task {
-            loadingModel.webContainerModel = await self.loadWebContainerModel(tab: tabIndex, url: url, navBarModel: loadingModel.navBarModel)
+            let webContainerModel = await self.loadWebContainerModel(tab: tabIndex, url: url, navBarModel: loadingModel.navBarModel)
+            // The session may have been evicted (or replaced) while the config loaded;
+            // don't populate an orphaned session with a container graph nobody owns
+            guard self.isCurrentSessionModel(loadingModel, tabIndex: tabIndex) else { return }
+            loadingModel.webContainerModel = webContainerModel
         }
+    }
+
+    /// True while the given loading model still belongs to a session the app is
+    /// accounting for: the displayed session or a cached (live) one.
+    private func isCurrentSessionModel(_ loadingModel: WebLoadingModel, tabIndex: Int) -> Bool {
+        if activeSession?.loadingModel === loadingModel {
+            return true
+        }
+        return sessions.session(for: tabIndex)?.loadingModel === loadingModel
     }
 
     private func configureSubmitAction(on loadingModel: WebLoadingModel, tabIndex: Int) {

--- a/lib/Sources/App/TabSession.swift
+++ b/lib/Sources/App/TabSession.swift
@@ -24,6 +24,12 @@ final class TabSession: Identifiable, LiveTabSession {
         loadingModel.webContainerModel != nil
     }
 
+    /// Relinquishes any keyboard focus held by the tab's web content; invoked when the
+    /// tab stops being the displayed one so its keyboard cannot linger over the next.
+    func resignFocus() {
+        loadingModel.webContainerModel?.webPageModel.resignFocus()
+    }
+
     /// Ends the web session: detaches the script handler (shutting down the tab's
     /// Bluetooth engine and disconnecting its peripherals) and releases the web view.
     /// Idempotent. The tab's URL remains in the grid; reopening reloads from scratch.

--- a/lib/Sources/DevicePicker/TabGatedDeviceSelector.swift
+++ b/lib/Sources/DevicePicker/TabGatedDeviceSelector.swift
@@ -31,6 +31,10 @@ public final class TabGatedDeviceSelector: InteractiveDeviceSelector {
     }
 
     public func showAdvertisement(peripheral: Peripheral, advertisement: Advertisement) async {
+        // A background tab's requestDevice briefly scans before its awaitSelection is
+        // rejected; never let those advertisements leak into the picker that the
+        // active tab may be presenting on the shared underlying selector
+        guard activeTabState.isActive(tab: tab) else { return }
         await wrapped.showAdvertisement(peripheral: peripheral, advertisement: advertisement)
     }
 

--- a/lib/Sources/Settings/CleanWebCache.swift
+++ b/lib/Sources/Settings/CleanWebCache.swift
@@ -1,12 +1,12 @@
 import WebKit
 
+/// Wipes all persisted web data. Returns only once the removal has completed so
+/// callers can sequence dependent work (e.g. reloading pages) after the wipe.
 @MainActor
-func cleanWebCache() {
+func cleanWebCache() async {
     HTTPCookieStorage.shared.removeCookies(since: Date.distantPast)
-
-    WKWebsiteDataStore.default().fetchDataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes()) { records in
-        records.forEach { record in
-            WKWebsiteDataStore.default().removeData(ofTypes: record.dataTypes, for: [record], completionHandler: {})
-        }
-    }
+    await WKWebsiteDataStore.default().removeData(
+        ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(),
+        modifiedSince: Date.distantPast
+    )
 }

--- a/lib/Sources/Settings/SettingsModel.swift
+++ b/lib/Sources/Settings/SettingsModel.swift
@@ -20,6 +20,10 @@ public final class SettingsModel {
     /// torn down; no page should keep in-memory state whose backing storage was wiped.
     public var onRemoveAllData: () -> Void = {}
 
+    /// Performs the actual web data wipe; injectable for tests. Must complete only
+    /// once the removal has finished so dependent work can be sequenced after it.
+    var removeAllWebData: @MainActor () async -> Void = { await cleanWebCache() }
+
     public var presentClearCacheDialogue: Bool = false
     public var presentDownloadsView: Bool = false
 
@@ -53,9 +57,13 @@ public final class SettingsModel {
     }
 
     func removeAllDataButtonTapped() {
-        cleanWebCache()
         presentClearCacheDialogue = false
-        onRemoveAllData()
+        Task {
+            // Reset sessions only after the wipe completes: a page reloaded while the
+            // removal is still in flight could read - and re-persist - "removed" data
+            await removeAllWebData()
+            onRemoveAllData()
+        }
     }
 
     func privacyPolicyButtonTapped() {

--- a/lib/Sources/WebView/JsEventDeliveryQueue.swift
+++ b/lib/Sources/WebView/JsEventDeliveryQueue.swift
@@ -4,9 +4,10 @@ import OSLog
 
 private let log = Logger(subsystem: "Topaz", category: "JsEventDeliveryQueue")
 
-enum JsEventDeliveryError: Error, LocalizedError {
+enum JsEventDeliveryError: Error, LocalizedError, Equatable {
     case overflow
     case cancelled
+    case timedOut
 
     var errorDescription: String? {
         switch self {
@@ -14,6 +15,8 @@ enum JsEventDeliveryError: Error, LocalizedError {
             return "Event delivery buffer overflowed"
         case .cancelled:
             return "Event delivery queue is cancelled"
+        case .timedOut:
+            return "Event delivery timed out"
         }
     }
 }
@@ -26,12 +29,16 @@ enum JsEventDeliveryError: Error, LocalizedError {
 /// previous log-and-continue semantics). If the buffer overflows - the page has been
 /// unresponsive under sustained event traffic for a long time - the queue cancels
 /// itself and reports it via `onOverflow`, whose owner is expected to tear down the
-/// session (converge-to-empty) rather than lose data silently.
+/// session (converge-to-empty) rather than lose data silently. A single delivery that
+/// never completes (WebKit's callback is not cancellable) is bounded by
+/// `deliveryTimeout` and converges the same way.
 @MainActor
 final class JsEventDeliveryQueue {
     static let defaultCapacity = 256
+    static let defaultDeliveryTimeout: Duration = .seconds(30)
 
     private let capacity: Int
+    private let deliveryTimeout: Duration
     private let deliver: @MainActor (JsEvent) async -> Result<Void, any Error>
     private let onOverflow: @MainActor () -> Void
     private var buffer: [JsEvent] = []
@@ -40,10 +47,12 @@ final class JsEventDeliveryQueue {
 
     init(
         capacity: Int = JsEventDeliveryQueue.defaultCapacity,
+        deliveryTimeout: Duration = JsEventDeliveryQueue.defaultDeliveryTimeout,
         deliver: @escaping @MainActor (JsEvent) async -> Result<Void, any Error>,
         onOverflow: @escaping @MainActor () -> Void
     ) {
         self.capacity = capacity
+        self.deliveryTimeout = deliveryTimeout
         self.deliver = deliver
         self.onOverflow = onOverflow
     }
@@ -84,12 +93,61 @@ final class JsEventDeliveryQueue {
                     return
                 }
                 let event = self.buffer.removeFirst()
-                let deliver = self.deliver
-                let result = await deliver(event)
+                let result = await self.deliverRacingTimeout(event)
                 if case let .failure(error) = result {
+                    if (error as? JsEventDeliveryError) == .timedOut {
+                        // WebKit never resumed the delivery callback: the page is
+                        // wedged (or its continuation lost). Converge like overflow -
+                        // abandon the page - instead of parking this task forever.
+                        guard !self.isCancelled else { return }
+                        log.error("Event delivery timed out for \(event.eventName, privacy: .public); abandoning the page")
+                        self.cancel()
+                        self.onOverflow()
+                        return
+                    }
                     log.error("Event delivery failed \(event.eventName, privacy: .public): \(error.localizedDescription, privacy: .public)")
                 }
             }
         }
+    }
+
+    /// Runs a delivery racing a timeout. The underlying `callAsyncJavaScript`
+    /// continuation is not cancellable, so a wedged page would otherwise strand the
+    /// drain task (and everything it keeps alive) forever; the loser of the race is
+    /// left to resolve - or leak inside WebKit - on its own.
+    private func deliverRacingTimeout(_ event: JsEvent) async -> Result<Void, any Error> {
+        let deliver = self.deliver
+        let timeout = self.deliveryTimeout
+        return await withCheckedContinuation { continuation in
+            let oneShot = OneShotResume(continuation)
+            let timerTask = Task { @MainActor in
+                do {
+                    try await Task.sleep(for: timeout)
+                    oneShot.resume(.failure(JsEventDeliveryError.timedOut))
+                } catch {
+                    // Cancelled: the delivery finished first
+                }
+            }
+            Task { @MainActor in
+                let result = await deliver(event)
+                timerTask.cancel()
+                oneShot.resume(result)
+            }
+        }
+    }
+}
+
+/// Resolves a continuation at most once when racing multiple completion paths.
+@MainActor
+private final class OneShotResume {
+    private var continuation: CheckedContinuation<Result<Void, any Error>, Never>?
+
+    init(_ continuation: CheckedContinuation<Result<Void, any Error>, Never>) {
+        self.continuation = continuation
+    }
+
+    func resume(_ result: Result<Void, any Error>) {
+        continuation?.resume(returning: result)
+        continuation = nil
     }
 }

--- a/lib/Sources/WebView/WebPageModel.swift
+++ b/lib/Sources/WebView/WebPageModel.swift
@@ -147,10 +147,15 @@ public class WebPageModel: Identifiable {
         return webView
     }
 
-    /// Explicitly tears down the web session: detaches the script handler (shutting down its
-    /// message processors and any BLE connections they hold), clears delegates, and releases
-    /// the web view. Idempotent. A subsequent `webView()` call starts a fresh session.
+    /// Explicitly tears down the web session: denies any pending permissions request
+    /// (so its continuation - and the script message reply awaiting it - cannot leak),
+    /// detaches the script handler (shutting down its message processors and any BLE
+    /// connections they hold), clears delegates, and releases the web view. Idempotent.
     public func teardown() {
+        // Resolve before the web-view guard: a request can be parked while the
+        // permissions alert chrome is unmounted (e.g. raised by a background tab)
+        closePermissionsRequest(allowed: false)
+        presentPermissionsDialog = false
         guard let webView = ownedWebView else { return }
         sessionController.deinitialize(webView: webView)
         ownedWebView = nil

--- a/lib/Sources/WebView/WebPageModel.swift
+++ b/lib/Sources/WebView/WebPageModel.swift
@@ -2,10 +2,13 @@ import Foundation
 import JsMessage
 import Navigation
 import Observation
+import OSLog
 import Permissions
 import SwiftUI
 import VirtualKeyboard
 import WebKit
+
+private let log = Logger(subsystem: "Topaz", category: "WebPageModel")
 
 // This is a workaround for an iOS issue that occurs with the view layout not being properly
 // redrawn when keyboard focus on a WebView TextField that has a tool bar shifts to a
@@ -32,6 +35,11 @@ public class WebPageModel: Identifiable {
     /// The web view is owned (strongly) by the model and survives until `teardown()`.
     @ObservationIgnored
     private var ownedWebView: WKWebView?
+
+    /// True once `teardown()` has run. Teardown is terminal: the session's owner has
+    /// stopped accounting for it, so `webView()` refuses to create a replacement.
+    @ObservationIgnored
+    private(set) var isTornDown = false
 
     public let config: WKWebViewConfiguration
     public let contextId: JsContextIdentifier
@@ -132,7 +140,14 @@ public class WebPageModel: Identifiable {
     }
 
     /// Returns the model-owned web view, creating and initializing it on first access.
-    func webView() -> WKWebView {
+    /// Returns nil once the session has been torn down: a torn-down model must never be
+    /// resurrected by a stray view update, because the replacement web view would live
+    /// outside the session cache's accounting and so would never be torn down again.
+    func webView() -> WKWebView? {
+        if isTornDown {
+            log.error("webView() requested after teardown for tab \(self.tab); refusing to resurrect the session")
+            return nil
+        }
         if let ownedWebView {
             return ownedWebView
         }
@@ -150,8 +165,10 @@ public class WebPageModel: Identifiable {
     /// Explicitly tears down the web session: denies any pending permissions request
     /// (so its continuation - and the script message reply awaiting it - cannot leak),
     /// detaches the script handler (shutting down its message processors and any BLE
-    /// connections they hold), clears delegates, and releases the web view. Idempotent.
+    /// connections they hold), clears delegates, and releases the web view. Idempotent
+    /// and terminal: `webView()` returns nil afterwards.
     public func teardown() {
+        isTornDown = true
         // Resolve before the web-view guard: a request can be parked while the
         // permissions alert chrome is unmounted (e.g. raised by a background tab)
         closePermissionsRequest(allowed: false)

--- a/lib/Sources/WebView/WebPageModel.swift
+++ b/lib/Sources/WebView/WebPageModel.swift
@@ -190,6 +190,13 @@ public class WebPageModel: Identifiable {
         self.url = url
     }
 
+    /// Relinquishes keyboard focus held by the web view's content. A web view moving
+    /// to the keep-alive underlay may otherwise remain first responder, leaving a
+    /// stale keyboard floating over whatever replaced it on screen.
+    public func resignFocus() {
+        ownedWebView?.endEditing(true)
+    }
+
     func webContentProcessDidTerminate() {
         onWebContentProcessTerminated?()
     }

--- a/lib/Sources/WebView/WebPageView.swift
+++ b/lib/Sources/WebView/WebPageView.swift
@@ -45,7 +45,9 @@ public struct WebPageView: View {
         // of its new host.
         func makeUIView(context: Context) -> WebPageHostUIView {
             let container = WebPageHostUIView()
-            let webView = model.webView()
+            // A torn-down model yields no web view; the empty container is a
+            // placeholder until SwiftUI removes this (already stale) host
+            guard let webView = model.webView() else { return container }
             container.host(webView)
             Task { @MainActor in
                 scrollView = webView.scrollView
@@ -54,7 +56,7 @@ public struct WebPageView: View {
         }
 
         func updateUIView(_ container: WebPageHostUIView, context: Context) {
-            let webView = model.webView()
+            guard let webView = model.webView() else { return }
             // Re-claim the web view in case another (now dismantled) host held it
             container.host(webView)
             model.sessionController.update(webView: webView, model: model)

--- a/lib/Tests/DevicePickerTests/TabGatedDeviceSelectorTests.swift
+++ b/lib/Tests/DevicePickerTests/TabGatedDeviceSelectorTests.swift
@@ -66,6 +66,33 @@ struct TabGatedDeviceSelectorTests {
     }
 
     @Test
+    func showAdvertisement_fromABackgroundTab_neverReachesThePicker() async throws {
+        let inner = DeviceSelector()
+        let activeTabState = ActiveTabState()
+        activeTabState.setActiveTab(1)
+        let activeTab = TabGatedDeviceSelector(tab: 1, activeTabState: activeTabState, wrapping: inner)
+        let backgroundTab = TabGatedDeviceSelector(tab: 2, activeTabState: activeTabState, wrapping: inner)
+
+        async let pendingResult = await activeTab.awaitSelection()
+        await Task.bigYield()
+        #expect(inner.isSelecting == true)
+        // A background tab's transient scan (before its own awaitSelection is
+        // rejected) must not inject its advertisements into the active picker
+        let intruder = FakePeripheral(id: zeroUuid, name: "intruder")
+        await backgroundTab.showAdvertisement(peripheral: intruder, advertisement: intruder.fakeAdvertisement(rssi: 0))
+        await Task.bigYield()
+        await activeTab.cancel()
+        let result = await pendingResult
+        switch result {
+        case let .success(success):
+            Issue.record("Unexpected result: \(success)")
+        case let .failure(error):
+            // presentedItems is empty: the intruder's advertisement was dropped
+            #expect(error == .cancelled(presentedItems: []))
+        }
+    }
+
+    @Test
     func awaitSelection_fromABackgroundTab_doesNotDisturbTheActiveTabsSelection() async throws {
         let inner = DeviceSelector()
         let activeTabState = ActiveTabState()

--- a/lib/Tests/SettingsTests/SettingsModelTests.swift
+++ b/lib/Tests/SettingsTests/SettingsModelTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+@testable import Settings
+import Testing
+
+@MainActor
+private final class WipeSpy {
+    private var gate: CheckedContinuation<Void, Never>?
+    private(set) var wipeStarted = false
+    private(set) var events: [String] = []
+
+    func beginWipe() async {
+        wipeStarted = true
+        await withCheckedContinuation { continuation in
+            gate = continuation
+        }
+        events.append("wiped")
+    }
+
+    func recordReset() {
+        events.append("reset")
+    }
+
+    func finishWipe() {
+        gate?.resume()
+        gate = nil
+    }
+}
+
+@MainActor
+@Suite(.timeLimit(.minutes(1)))
+struct SettingsModelTests {
+
+    @Test
+    func removeAllData_resetsSessionsOnlyAfterTheWipeCompletes() async throws {
+        let model = SettingsModel()
+        let spy = WipeSpy()
+        model.removeAllWebData = { await spy.beginWipe() }
+        model.onRemoveAllData = { spy.recordReset() }
+
+        model.removeAllDataButtonTapped()
+        #expect(model.presentClearCacheDialogue == false)
+        while spy.wipeStarted == false {
+            await Task.yield()
+        }
+        // The wipe is still in flight: sessions must not have been reset yet, or a
+        // reloading page could read - and re-persist - the data being removed
+        #expect(spy.events.isEmpty)
+
+        spy.finishWipe()
+        while spy.events.count < 2 {
+            await Task.yield()
+        }
+        #expect(spy.events == ["wiped", "reset"])
+    }
+}

--- a/lib/Tests/WebViewTests/JsEventDeliveryQueueTests.swift
+++ b/lib/Tests/WebViewTests/JsEventDeliveryQueueTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import JsMessage
+import TestHelpers
 import Testing
 @testable import WebView
 
@@ -10,9 +11,10 @@ private final class DeliverySpy {
     var gate: CheckedContinuation<Void, Never>?
     var blockDeliveries = false
 
-    func makeQueue(capacity: Int = 4) -> JsEventDeliveryQueue {
+    func makeQueue(capacity: Int = 4, deliveryTimeout: Duration = .seconds(30)) -> JsEventDeliveryQueue {
         JsEventDeliveryQueue(
             capacity: capacity,
+            deliveryTimeout: deliveryTimeout,
             deliver: { [weak self] event in
                 guard let self else { return .success(()) }
                 if self.blockDeliveries {
@@ -126,6 +128,38 @@ struct JsEventDeliveryQueueTests {
         await Task.yield()
         // The event that was mid-delivery may complete, but buffered ones are dropped
         #expect(!spy.delivered.contains("two"))
+    }
+
+    @Test func delivery_thatNeverCompletesTimesOutAndAbandonsThePage() async throws {
+        let spy = DeliverySpy()
+        let queue = spy.makeQueue(deliveryTimeout: .milliseconds(50))
+        spy.blockDeliveries = true
+        queue.enqueue(event("one"))
+        // WebKit's delivery callback is not cancellable; the queue must not park its
+        // drain task forever behind it - the timeout converges like an overflow
+        while spy.overflowCount == 0 {
+            await Task.yield()
+        }
+        #expect(queue.isCancelled)
+        #expect(spy.delivered.isEmpty)
+        // Releasing the parked delivery afterwards is harmless
+        spy.blockDeliveries = false
+        spy.openGate()
+        await Task.bigYield()
+        #expect(spy.overflowCount == 1)
+    }
+
+    @Test func delivery_thatCompletesInTimeDoesNotTrip() async throws {
+        let spy = DeliverySpy()
+        let queue = spy.makeQueue(deliveryTimeout: .seconds(30))
+        queue.enqueue(event("one"))
+        queue.enqueue(event("two"))
+        while spy.delivered.count < 2 {
+            await Task.yield()
+        }
+        #expect(spy.delivered == ["one", "two"])
+        #expect(spy.overflowCount == 0)
+        #expect(!queue.isCancelled)
     }
 
     @Test func drainResumesAfterBacklogClears() async throws {

--- a/lib/Tests/WebViewTests/WebPageModelTests.swift
+++ b/lib/Tests/WebViewTests/WebPageModelTests.swift
@@ -44,4 +44,33 @@ struct WebPageModelTests {
         model.teardown()
         #expect(model.presentPermissionsDialog == false)
     }
+
+    @Test
+    func webView_beforeTeardownReturnsAStableInstance() async throws {
+        let model = makeModel()
+        let first = model.webView()
+        let second = model.webView()
+        #expect(first != nil)
+        #expect(first === second)
+    }
+
+    @Test
+    func webView_afterTeardownRefusesToResurrectTheSession() async throws {
+        let model = makeModel()
+        let original = model.webView()
+        #expect(original != nil)
+        model.teardown()
+        #expect(model.isTornDown)
+        // A stray view update after eviction must not conjure a replacement web view:
+        // it would live outside the session cache's accounting and never be torn down
+        #expect(model.webView() == nil)
+    }
+
+    @Test
+    func teardown_beforeAnyWebViewExistsIsStillTerminal() async throws {
+        let model = makeModel()
+        model.teardown()
+        #expect(model.isTornDown)
+        #expect(model.webView() == nil)
+    }
 }

--- a/lib/Tests/WebViewTests/WebPageModelTests.swift
+++ b/lib/Tests/WebViewTests/WebPageModelTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Navigation
+import Testing
+import VirtualKeyboard
+import WebKit
+@testable import WebView
+
+@MainActor
+@Suite(.timeLimit(.minutes(1)))
+struct WebPageModelTests {
+
+    private func makeModel(url: URL = URL(string: "https://pending-permissions.example")!) -> WebPageModel {
+        WebPageModel(
+            tab: 1,
+            url: url,
+            config: WKWebViewConfiguration(),
+            navigator: WebNavigator(),
+            virtualKeyboardModel: VirtualKeyboardModel()
+        )
+    }
+
+    @Test
+    func teardown_deniesAPendingPermissionsRequest() async throws {
+        let model = makeModel()
+        // Establish the page's origin so authorization gets requested rather than refused outright
+        model.didBeginLoading(url: URL(string: "https://pending-permissions.example")!)
+        async let pendingAuthorization = model.requestAuthorization()
+        while model.presentPermissionsDialog == false {
+            await Task.yield()
+        }
+        // Tearing down with the request still parked (e.g. the tab was evicted while
+        // backgrounded, before its permissions alert could ever mount) must deny it
+        // rather than leak the continuation and hang the page's promise forever
+        model.teardown()
+        let authorized = await pendingAuthorization
+        #expect(authorized == false)
+        #expect(model.presentPermissionsDialog == false)
+    }
+
+    @Test
+    func teardown_withoutAPendingRequestIsHarmless() async throws {
+        let model = makeModel()
+        model.teardown()
+        model.teardown()
+        #expect(model.presentPermissionsDialog == false)
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Review fixes for #298 (stacked)

**Stacked on #298** (`dt/cursor/topaz-multiple-tab-support-201b`) — the first 9 commits here are #298 itself; the top nine commits are new (2 critical fixes + 7 follow-up suggestions from the review). Draft PR opened primarily to run CI on the stacked commits (CI only triggers on PRs targeting `main`). Intended to be merged into #298's branch (or rebased once #298 lands), not merged to `main` independently.

## Critical fixes

### 1. Resolve pending permissions request on session teardown (`519f629`)

`WebPageModel.teardown()` now denies (and thereby releases) a parked permissions continuation before releasing the web view, and resets `presentPermissionsDialog`. Without this, a background tab whose page requested Bluetooth authorization — the permissions alert chrome only mounts for the active tab — would, upon eviction, leak the `CheckedContinuation`, hold the `WKScriptMessage` reply open forever, and leave the page's promise permanently unsettled.

### 2. Make session teardown terminal: `webView()` refuses to resurrect (`aca6c8a`)

`teardown()` marks the model as torn down (`isTornDown`) and `webView()` returns `nil` from then on instead of lazily creating a replacement. Previously a stray host update after eviction could silently spin up a fresh `WKWebView` and re-initialize the session controller on a model that `TabSessionCache` no longer accounts for — a zombie session that would never be evicted or torn down again.

## Follow-up fixes (review suggestions)

- **`baeec30`** — `TabGatedDeviceSelector` also gates `showAdvertisement`: a background tab's transient scan (before its `awaitSelection` is rejected) can no longer inject its advertisements into the active tab's open picker.
- **`6fc2bb0`** — `performInitialLoad` now mirrors the submit path's staleness guard: a session evicted while the web config loaded no longer receives an orphaned `WebContainerModel`.
- **`3dee714`** — Memory warning while the tab grid is showing evicts *all* sessions (nothing is displayed, so the still-pinned last-viewed tab is background too).
- **`742a5b1`** — Re-activating a live session clears a stale `goBackToPriorPage` closure; only the window.open flow re-installs it.
- **`96948c7`** — `JsEventDeliveryQueue` bounds each delivery with a 30 s timeout: a page that never resumes `callAsyncJavaScript`'s (non-cancellable) callback converges like an overflow instead of stranding the drain task forever.
- **`a46fea2`** — The outgoing session resigns keyboard focus when the displayed tab changes, so a web view moving to the keep-alive underlay can't leave a stale keyboard over the incoming view. (The underlay keep-alive technique itself stays as-is, pending #297 on-device verification.)
- **`5060fb1`** — "Remove all data" awaits the (now fully async) web data wipe before resetting sessions, so the reloaded page can't race the removal and re-persist wiped data. New `SettingsTests` target with an ordering test.

## Tests

- New `WebViewTests/WebPageModelTests.swift` (5 tests): teardown denies pending permissions (would hang pre-fix), teardown idempotent/terminal, `webView()` stable pre-teardown and `nil` post-teardown.
- `TabGatedDeviceSelectorTests`: background `showAdvertisement` never reaches the picker.
- `JsEventDeliveryQueueTests`: wedged delivery times out and abandons the page; timely deliveries don't trip.
- New `SettingsTests/SettingsModelTests.swift`: session reset fires only after the wipe completes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61490429-7d9a-4be6-ae9c-60c8b9dd4d34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61490429-7d9a-4be6-ae9c-60c8b9dd4d34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

