### PR TITLE
Add Saucelabs IPA upload to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,5 +77,17 @@ jobs:
       - run: make XCODE_CONFIG=Release validate-ipa
       - run: make XCODE_CONFIG=Release upload-ipa
 
+      - name: Upload IPA to Saucelabs
+        env:
+          SAUCELABS_USERNAME: ${{ secrets.SAUCELABS_USERNAME }}
+          SAUCELABS_ACCESS_KEY: ${{ secrets.SAUCELABS_ACCESS_KEY }}
+          SAUCELABS_ORG_ID: ${{ secrets.SAUCELABS_ORG_ID }}
+        run: |
+          curl -u "$SAUCELABS_USERNAME:$SAUCELABS_ACCESS_KEY" \
+            -X POST \
+            -F "payload=@artifacts/topaz.ipa" \
+            -F "name=topaz-${TAG##*/}-${{ github.run_number }}.ipa" \
+            "https://api.us-west-1.saucelabs.com/v1/storage/upload?teamId=$SAUCELABS_ORG_ID"
+
       - uses: ./.github/actions/ios-ci-signing-cleanup
         if: always()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,12 +82,12 @@ jobs:
           SAUCELABS_USERNAME: ${{ secrets.SAUCELABS_USERNAME }}
           SAUCELABS_ACCESS_KEY: ${{ secrets.SAUCELABS_ACCESS_KEY }}
           SAUCELABS_ORG_ID: ${{ secrets.SAUCELABS_ORG_ID }}
-        run: |
-          curl -fS -u "$SAUCELABS_USERNAME:$SAUCELABS_ACCESS_KEY" \
-            -X POST \
-            -F "payload=@artifacts/topaz.ipa" \
-            -F "name=topaz-${TAG##*/}-${{ github.run_number }}.ipa" \
-            "https://api.us-west-1.saucelabs.com/v1/storage/upload?teamId=$SAUCELABS_ORG_ID"
+        run: >
+          curl --fail-with-body -u "$SAUCELABS_USERNAME:$SAUCELABS_ACCESS_KEY"
+          -X POST
+          -F "payload=@artifacts/topaz.ipa"
+          -F "name=topaz-${TAG##*/}-${{ github.run_number }}.ipa"
+          "https://api.us-west-1.saucelabs.com/v1/storage/upload?teamId=$SAUCELABS_ORG_ID"
 
       - uses: ./.github/actions/ios-ci-signing-cleanup
         if: always()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,7 +83,7 @@ jobs:
           SAUCELABS_ACCESS_KEY: ${{ secrets.SAUCELABS_ACCESS_KEY }}
           SAUCELABS_ORG_ID: ${{ secrets.SAUCELABS_ORG_ID }}
         run: |
-          curl -u "$SAUCELABS_USERNAME:$SAUCELABS_ACCESS_KEY" \
+          curl -fS -u "$SAUCELABS_USERNAME:$SAUCELABS_ACCESS_KEY" \
             -X POST \
             -F "payload=@artifacts/topaz.ipa" \
             -F "name=topaz-${TAG##*/}-${{ github.run_number }}.ipa" \


### PR DESCRIPTION
## Summary
- Adds a Saucelabs IPA upload step to the `Publish` GitHub Actions workflow, running after the existing App Store upload on `release/**` tags.
- Uploads `artifacts/topaz.ipa` to Saucelabs storage via API using `SAUCELABS_USERNAME`, `SAUCELABS_ACCESS_KEY`, and `SAUCELABS_ORG_ID` repository secrets.

## Test plan
- [x] Confirm `SAUCELABS_USERNAME`, `SAUCELABS_ACCESS_KEY`, and `SAUCELABS_ORG_ID` secrets are configured in the repository
- [x] Trigger a `release/**` tag publish and verify the Saucelabs upload step completes successfully
- [x] Confirm the uploaded IPA appears in Saucelabs storage with the expected name (`topaz-<version>-<build>.ipa`)


Made with [Cursor](https://cursor.com)