### PR TITLE
Add Sauce Labs simulator build upload workflow

### DIFF
--- a/.github/workflows/upload-simulator-saucelabs.yml
+++ b/.github/workflows/upload-simulator-saucelabs.yml
@@ -1,0 +1,79 @@
+name: Upload simulator to Sauce Labs
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: upload-simulator-saucelabs-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  upload_simulator_build:
+    if: github.event.pull_request.merged == true
+    name: Build Simulator App and upload to Sauce Labs
+    runs-on: [macOS-26]
+    timeout-minutes: 45
+    env:
+      SAUCELABS_USERNAME: ${{ secrets.SAUCELABS_USERNAME }}
+      SAUCELABS_ACCESS_KEY: ${{ secrets.SAUCELABS_ACCESS_KEY }}
+      SAUCELABS_ORG_ID: ${{ secrets.SAUCELABS_ORG_ID }}
+      SAUCELABS_REGION: us-west-1
+      SAUCE_STORAGE_FILENAME: topaz-simulator.zip
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+
+      - run: xcodes select
+
+      - run: xcodebuild -version
+
+      - name: Resolve app version
+        id: version
+        run: |
+          APP_VERSION="$(git describe --tags --match 'release/*' --abbrev=0 2>/dev/null | sed 's#^release/##')"
+          echo "marketing=${APP_VERSION:-1.0.0}" >> "$GITHUB_OUTPUT"
+          echo "build=${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+
+      - run: make clean
+
+      - name: Build ad-hoc signed simulator app
+        run: >
+          make build
+          PLATFORM=GENERIC_SIMULATOR
+          XCODE_EXTRA_PARAMS='CODE_SIGNING_ALLOWED=YES MARKETING_VERSION=${{ steps.version.outputs.marketing }} CURRENT_PROJECT_VERSION=${{ steps.version.outputs.build }}'
+
+      - name: Zip Simulator .app
+        run: |
+          PRODUCT_DIR=".derivedData/Debug/Build/Products/Debug-iphonesimulator"
+          APP_PATH="$(find "$PRODUCT_DIR" -maxdepth 1 -name '*.app' -print -quit)"
+          if [[ -z "$APP_PATH" ]]; then
+            echo "No .app bundle found in $PRODUCT_DIR after build"
+            exit 1
+          fi
+          mkdir -p artifacts
+          (cd "$(dirname "$APP_PATH")" && zip -qr "$GITHUB_WORKSPACE/artifacts/${SAUCE_STORAGE_FILENAME}" "$(basename "$APP_PATH")")
+
+      - name: Upload to Sauce Labs storage
+        run: >
+          curl --fail-with-body
+          -u "$SAUCELABS_USERNAME:$SAUCELABS_ACCESS_KEY"
+          -X POST
+          -F "payload=@artifacts/${SAUCE_STORAGE_FILENAME}"
+          -F "name=${SAUCE_STORAGE_FILENAME}" 
+          "https://api.${SAUCELABS_REGION}.saucelabs.com/v1/storage/upload?teamId=${SAUCELABS_ORG_ID}"
+
+      - if: always()
+        run: |
+          {
+            echo "#### Sauce Labs simulator build"
+            echo "Storage filename: ${SAUCE_STORAGE_FILENAME}"
+            echo "Commit: ${{ github.sha }}"
+            echo "Run: ${{ github.run_number }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/build.mk
+++ b/build.mk
@@ -24,6 +24,7 @@ IOS_SIM_UUID := $(shell ./scripts/find_optimal_sim_uuid.sh)
 PLATFORM_IOS := platform=iOS Simulator,id=$(IOS_SIM_UUID)
 PLATFORM_MACOS := platform=macOS,arch=arm64,variant=Designed for iPad
 PLATFORM_GENERIC := generic/platform=iOS
+PLATFORM_GENERIC_SIMULATOR := generic/platform=iOS Simulator
 
 XCODE_DESTINATION := $(PLATFORM_$(PLATFORM))
 
@@ -61,12 +62,14 @@ test: $(TEST_MODULES)
 	$(XCODEBUILD)
 
 boot-simulator:
-	@if [ ! -z "$(IOS_SIM_UUID)" ]; then \
+	@if [ "$(PLATFORM)" != "IOS" ]; then \
+		exit 0; \
+	elif [ ! -z "$(IOS_SIM_UUID)" ]; then \
 		xcrun simctl list devices available; \
 		echo "Booting simulator for iOS with id: $(PLATFORM_ID)"; \
 		xcrun simctl list | grep $(PLATFORM_ID) | grep -q Booted || xcrun simctl boot $(PLATFORM_ID); \
 		open -a Simulator --args -CurrentDeviceUDID $(PLATFORM_ID); \
-	elif [ "$(PLATFORM)" = "IOS" ]; then \
+	else \
 		xcrun simctl list devices available; \
 		xcodebuild -showdestinations -scheme "$(XCODE_SCHEME)" -project $(XCODE_PROJECT); \
 		echo "ERROR: Compatible iOS simulator not found"; \


### PR DESCRIPTION
## Summary
Adds `upload-simulator-saucelabs.yml`: builds a Debug **iOS Simulator** app and uploads it to Sauce Labs App Storage on every push to `main`, under the fixed filename `topaz-simulator.zip` so consumers can reference `storage:filename=topaz-simulator.zip` and always get the latest build.

This complements the release `.ipa` upload — an `.ipa` only installs on real devices, but the conx daily-login Sauce suite runs on an iOS Simulator, which needs a zipped `.app`.

## Key detail: the build must be signed
`make build` sets `CODE_SIGNING_ALLOWED=NO` for Debug simulator builds, which leaves a half-signed bundle (linker ad-hoc stub, no `_CodeSignature` seal). WebKit misbehaves inside such a bundle on the simulator — the web app fails to initialize ("Setup failed") and Appium sees no webview context. So this builds with xcodebuild's normal **ad-hoc** signing pass (`CODE_SIGN_IDENTITY=-`, no certificates or secrets required), which produces a properly sealed bundle.

The uploaded build is also stamped with the real marketing version (from the latest `release/*` tag) and the CI run number, so Sauce shows e.g. `2.2.1 / <run>` instead of `1.0.0 / 1`.

## Validated
Full conx daily-login suite passed end-to-end against this build — all regions (US/CA/GB/KW), navigate → login → credentials → landed. Reproducibility confirmed across multiple CI build → upload → test cycles.

https://github.com/JuulLabs/conx/actions/runs/29479339745


