### PR TITLE
Add support for `mailto`, `sms`, and `tel` schemes.

### DIFF
--- a/lib/Sources/Navigation/NavigationEngine+WKNavigationDelegate.swift
+++ b/lib/Sources/Navigation/NavigationEngine+WKNavigationDelegate.swift
@@ -16,10 +16,8 @@ extension NavigationEngine: WKNavigationDelegate {
             return .cancel
         }
         guard let newRequest = NavigationRequest(action: navigationAction) else {
-            UIApplication.shared.open(url, options: [:]) { success in
-                if !success {
-                    log.warning("System URL open denied for \(url.absoluteString)")
-                }
+            delegateURLToSystem(url) {
+                log.warning("System URL open denied for \(url.absoluteString)")
             }
             log.debug("Request delegated to system action=\(navigationAction)")
             return .cancel

--- a/lib/Sources/Navigation/NavigationEngine+WKUIDelegate.swift
+++ b/lib/Sources/Navigation/NavigationEngine+WKUIDelegate.swift
@@ -10,6 +10,11 @@ extension NavigationEngine: WKUIDelegate {
             log.debug("Request opens in new window action=\(navigationAction)")
             latestRequest = nil
             navigator.stopLoadingAndOpenNewWindow(url: request.url)
+        } else if let url = navigationAction.request.url, url.shouldDelegateToSystem {
+            delegateURLToSystem(url) {
+                log.warning("System URL open denied for \(url.absoluteString)")
+            }
+            log.debug("New-window request delegated to system action=\(navigationAction)")
         } else {
             log.warning("Request for new window ignored action=\(navigationAction)")
         }

--- a/lib/Sources/Navigation/NavigationEngine+WKUIDelegate.swift
+++ b/lib/Sources/Navigation/NavigationEngine+WKUIDelegate.swift
@@ -10,21 +10,20 @@ extension NavigationEngine: WKUIDelegate {
             log.warning("NavigationAction request url is nil")
             return nil
         }
-        
+
         guard let request = NavigationRequest(action: navigationAction) else {
             delegateURLToSystem(url)
             return nil
         }
-        
+
         guard request.kind == .newWindow else {
             log.warning("Request for new window ignored action=\(navigationAction)")
             return nil
         }
-        
+
         log.debug("Request opens in new window action=\(navigationAction)")
         latestRequest = nil
         navigator.stopLoadingAndOpenNewWindow(url: request.url)
         return nil
     }
 }
-    

--- a/lib/Sources/Navigation/NavigationEngine+WKUIDelegate.swift
+++ b/lib/Sources/Navigation/NavigationEngine+WKUIDelegate.swift
@@ -6,18 +6,25 @@ private let log = Logger(subsystem: "WebView", category: "UIDelegate")
 
 extension NavigationEngine: WKUIDelegate {
     public func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
-        if let request = NavigationRequest(action: navigationAction), request.kind == .newWindow {
-            log.debug("Request opens in new window action=\(navigationAction)")
-            latestRequest = nil
-            navigator.stopLoadingAndOpenNewWindow(url: request.url)
-        } else if let url = navigationAction.request.url, url.shouldDelegateToSystem {
-            delegateURLToSystem(url) {
-                log.warning("System URL open denied for \(url.absoluteString)")
-            }
-            log.debug("New-window request delegated to system action=\(navigationAction)")
-        } else {
-            log.warning("Request for new window ignored action=\(navigationAction)")
+        guard let url = navigationAction.request.url else {
+            log.warning("NavigationAction request url is nil")
+            return nil
         }
+        
+        guard let request = NavigationRequest(action: navigationAction) else {
+            delegateURLToSystem(url)
+            return nil
+        }
+        
+        guard request.kind == .newWindow else {
+            log.warning("Request for new window ignored action=\(navigationAction)")
+            return nil
+        }
+        
+        log.debug("Request opens in new window action=\(navigationAction)")
+        latestRequest = nil
+        navigator.stopLoadingAndOpenNewWindow(url: request.url)
         return nil
     }
 }
+    

--- a/lib/Sources/Navigation/NavigationEngine.swift
+++ b/lib/Sources/Navigation/NavigationEngine.swift
@@ -1,6 +1,12 @@
 import Foundation
 import WebKit
 
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
 @MainActor
 public final class NavigationEngine: NSObject {
     private var recentDownloads: [URL] = []
@@ -63,5 +69,19 @@ public final class NavigationEngine: NSObject {
 
     func isRecentDownload(_ url: URL) -> Bool {
         recentDownloads.contains(url)
+    }
+
+    func delegateURLToSystem(_ url: URL, onDenied: @escaping () -> Void = {}) {
+        #if canImport(UIKit)
+        UIApplication.shared.open(url, options: [:]) { success in
+            if !success {
+                onDenied()
+            }
+        }
+        #elseif canImport(AppKit)
+        if !NSWorkspace.shared.open(url) {
+            onDenied()
+        }
+        #endif
     }
 }

--- a/lib/Sources/Navigation/NavigationEngine.swift
+++ b/lib/Sources/Navigation/NavigationEngine.swift
@@ -1,11 +1,6 @@
 import Foundation
 import WebKit
-
-#if canImport(UIKit)
 import UIKit
-#elseif canImport(AppKit)
-import AppKit
-#endif
 
 @MainActor
 public final class NavigationEngine: NSObject {
@@ -72,16 +67,10 @@ public final class NavigationEngine: NSObject {
     }
 
     func delegateURLToSystem(_ url: URL, onDenied: @escaping () -> Void = {}) {
-        #if canImport(UIKit)
         UIApplication.shared.open(url, options: [:]) { success in
             if !success {
                 onDenied()
             }
         }
-        #elseif canImport(AppKit)
-        if !NSWorkspace.shared.open(url) {
-            onDenied()
-        }
-        #endif
     }
 }

--- a/lib/Sources/Navigation/NavigationRequest.swift
+++ b/lib/Sources/Navigation/NavigationRequest.swift
@@ -70,10 +70,21 @@ private let downloadSchemes: Set<String> = ["blob"]
 private let httpSchemes: Set<String> = ["https", "http"]
 private let acceptedSchemes: Set<String> = downloadSchemes.union(httpSchemes).union(["about", "data"])
 
-private extension URL {
-    var isSchemeSupported: Bool {
+extension URL {
+    var isWebNavigableScheme: Bool {
         guard let scheme = scheme?.lowercased() else { return false }
         return acceptedSchemes.contains(scheme)
+    }
+
+    /// External schemes such as `mailto:` and `tel:` that should be handed off to the system.
+    var shouldDelegateToSystem: Bool {
+        scheme != nil && !isWebNavigableScheme
+    }
+}
+
+private extension URL {
+    var isSchemeSupported: Bool {
+        isWebNavigableScheme
     }
 
     var hasDownloadScheme: Bool {

--- a/lib/Sources/Navigation/NavigationRequest.swift
+++ b/lib/Sources/Navigation/NavigationRequest.swift
@@ -70,21 +70,10 @@ private let downloadSchemes: Set<String> = ["blob"]
 private let httpSchemes: Set<String> = ["https", "http"]
 private let acceptedSchemes: Set<String> = downloadSchemes.union(httpSchemes).union(["about", "data"])
 
-extension URL {
-    var isWebNavigableScheme: Bool {
-        guard let scheme = scheme?.lowercased() else { return false }
-        return acceptedSchemes.contains(scheme)
-    }
-
-    /// External schemes such as `mailto:` and `tel:` that should be handed off to the system.
-    var shouldDelegateToSystem: Bool {
-        scheme != nil && !isWebNavigableScheme
-    }
-}
-
 private extension URL {
     var isSchemeSupported: Bool {
-        isWebNavigableScheme
+        guard let scheme = scheme?.lowercased() else { return false }
+        return acceptedSchemes.contains(scheme)
     }
 
     var hasDownloadScheme: Bool {

--- a/lib/Tests/NavigationTests/NavigationRequestTests.swift
+++ b/lib/Tests/NavigationTests/NavigationRequestTests.swift
@@ -151,6 +151,35 @@ struct NavigationRequestTests {
     }
 
     @Test(arguments: [
+        ("mailto:test@example.com", true),
+        ("tel:+15551234567", true),
+        ("sms:+15551234567", true),
+        ("https://test.com", false),
+        ("http://test.com", false),
+        ("about:blank", false),
+        ("data:text/html,hi", false),
+        ("blob:https://test.com/abc", false),
+    ])
+    func shouldDelegateToSystem(url: String, expected: Bool) throws {
+        let parsedUrl = try #require(URL(string: url))
+        #expect(parsedUrl.shouldDelegateToSystem == expected)
+    }
+
+    @Test
+    func initFromAction_withMailtoScheme_isNil() throws {
+        let mailtoUrl = try #require(URL(string: "mailto:test@example.com"))
+        let sourceFrame = MockFrameInfo(
+            isMainFrame: { true }
+        ).immortalize(in: &Self.retainBucket)
+        let action = MockAction(
+            request: { URLRequest(url: mailtoUrl) },
+            sourceFrame: { sourceFrame },
+            targetFrame: { nil }
+        )
+        #expect(NavigationRequest(action: action) == nil)
+    }
+
+    @Test(arguments: [
         (url: "https://test.com", method: "GET", isDownload: false, expected: true),
         (url: "http://test.com", method: "GET", isDownload: false, expected: true),
         (url: "https://test.com", method: "POST", isDownload: false, expected: false),

--- a/lib/Tests/NavigationTests/NavigationRequestTests.swift
+++ b/lib/Tests/NavigationTests/NavigationRequestTests.swift
@@ -150,21 +150,6 @@ struct NavigationRequestTests {
         #expect(sut?.httpMethod == "POST")
     }
 
-    @Test(arguments: [
-        ("mailto:test@example.com", true),
-        ("tel:+15551234567", true),
-        ("sms:+15551234567", true),
-        ("https://test.com", false),
-        ("http://test.com", false),
-        ("about:blank", false),
-        ("data:text/html,hi", false),
-        ("blob:https://test.com/abc", false),
-    ])
-    func shouldDelegateToSystem(url: String, expected: Bool) throws {
-        let parsedUrl = try #require(URL(string: url))
-        #expect(parsedUrl.shouldDelegateToSystem == expected)
-    }
-
     @Test
     func initFromAction_withMailtoScheme_isNil() throws {
         let mailtoUrl = try #require(URL(string: "mailto:test@example.com"))


### PR DESCRIPTION
Fixes an issue where common non-http(s) schemes (`mailto`, `tel`, `sms`) did nothing when tapped.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized navigation-handoff change with tests; behavior is limited to opening external URLs outside the web view.
> 
> **Overview**
> **External URL schemes** (`mailto:`, `tel:`, `sms:`, and any non–web-navigable scheme) are now opened via the OS instead of being dropped or only handled on the main navigation path.
> 
> `URL` gains **`shouldDelegateToSystem`** (anything with a scheme that is not http/https/about/data/blob) and the in-webview scheme check is renamed to **`isWebNavigableScheme`**. Unsupported navigations still cancel in the web view, but opening is centralized in **`delegateURLToSystem`**, which uses `UIApplication.shared.open` on iOS and `NSWorkspace.shared.open` on macOS, with a shared denial callback for logging.
> 
> **New-window** navigations (`WKUIDelegate`) now use the same delegation when the target URL is a system scheme, so links like `mailto:` opened in a new window are handled like normal link taps. Tests cover scheme classification and that `NavigationRequest` is nil for `mailto:` actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6afb6d998f4809eeef8d895227b3563718f03316. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->