### PR TITLE
Bump to macOS-26 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: [macOS-15]
+    runs-on: [macOS-26]
     steps:
       - uses: actions/checkout@v7
       - run: brew install swiftlint
@@ -15,7 +15,7 @@ jobs:
       - run: swiftlint lint --strict --reporter github-actions-logging
   build:
     name: Build
-    runs-on: [macOS-15]
+    runs-on: [macOS-26]
     steps:
       - uses: actions/checkout@v7
       - run: xcrun simctl list runtimes
@@ -25,7 +25,7 @@ jobs:
       - run: make build
   test:
     name: Test
-    runs-on: [macOS-15]
+    runs-on: [macOS-26]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ on:
 
 jobs:
   publish:
-    runs-on: [macOS-15]
+    runs-on: [macOS-26]
     # Set a timeout to kill if it hangs which can happen if permissions need fixing and it hangs on a GUI prompt
     timeout-minutes: 30
     env:

--- a/.github/workflows/upload-developer-ipa-s3.yml
+++ b/.github/workflows/upload-developer-ipa-s3.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   upload_developer_ipa:
     name: Build Debug IPA and upload to S3
-    runs-on: [macOS-15]
+    runs-on: [macOS-26]
     timeout-minutes: 45
     env:
       API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}

--- a/lib/Tests/EventBusTests/EventBusListenerTests.swift
+++ b/lib/Tests/EventBusTests/EventBusListenerTests.swift
@@ -91,7 +91,10 @@ struct EventBusListenerTests {
         }
         let event = TestEventOne(id: "test-event", lookup: .exact(key: systemStateKey))
         sut.enqueueEvent(event)
-        let outcome = await XCTWaiter().fulfillment(of: [eventReceivedExpectation], timeout: 0.1)
+        // `enqueueEvent` is fire-and-forget (drained by a background task), so allow
+        // headroom for the cold async path to spin up on loaded CI runners. Matches the
+        // timeout used by `enqueueEvent_manyEvents_emitInOrder`.
+        let outcome = await XCTWaiter().fulfillment(of: [eventReceivedExpectation], timeout: 0.5)
         #expect(outcome == .completed)
     }
 


### PR DESCRIPTION
The `macOS-latest` target started resolving to `macOS-26` as of June so lets pin to that version now.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Runner image-only change with no application or signing logic edits; main risk is transient CI breakage if the new image differs in Xcode or tooling.
> 
> **Overview**
> Updates all **macOS** GitHub Actions jobs from **`macOS-15`** to **`macOS-26`** so CI matches where **`macOS-latest`** resolves today, instead of drifting when GitHub changes the floating label.
> 
> **`ci.yml`**: **lint**, **build**, and **test** now run on **macOS-26** (the **js** job stays on **ubuntu-latest**). **`publish.yml`** and **`upload-developer-ipa-s3.yml`** use the same runner for release and developer IPA builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca5fe77aa5cb1124cc65e9a81dd7d07dd2e58d05. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->