### PR TITLE
Validate signing certificates with system LibreSSL

### DIFF
--- a/.github/actions/ios-ci-signing-prepare/action.yml
+++ b/.github/actions/ios-ci-signing-prepare/action.yml
@@ -37,9 +37,11 @@ runs:
       shell: bash
       run: |
         DEV_CERT=$API_KEY_DIR/dev_cert.p12
-        openssl pkcs12 -in "$DEV_CERT" -out client_cert.pem -nokeys -passin "pass:$APPLE_CERTIFICATE_PASSKEY"
-        openssl x509 -in client_cert.pem -noout -text
-        CERT_DATE=$(openssl x509 -in client_cert.pem -noout -enddate | cut -d= -f 2)
+        # Apple .p12 exports are encrypted with RC2-40-CBC, which the OpenSSL 3 on PATH refuses to
+        # read without its legacy provider. System LibreSSL supports it, so call it explicitly.
+        /usr/bin/openssl pkcs12 -in "$DEV_CERT" -out client_cert.pem -nokeys -passin "pass:$APPLE_CERTIFICATE_PASSKEY"
+        /usr/bin/openssl x509 -in client_cert.pem -noout -text
+        CERT_DATE=$(/usr/bin/openssl x509 -in client_cert.pem -noout -enddate | cut -d= -f 2)
         rm client_cert.pem
         echo "Certificate expiration date: $CERT_DATE"
         test $(date -j -f '%b %d %H:%M:%S %Y %Z' "$CERT_DATE" '+%s') -gt $(date '+%s')
@@ -56,9 +58,10 @@ runs:
       shell: bash
       run: |
         DISTRIBUTION_CERT=$API_KEY_DIR/distribution_cert.p12
-        openssl pkcs12 -in "$DISTRIBUTION_CERT" -out distribution_client_cert.pem -nokeys -passin "pass:$APPLE_CERTIFICATE_PASSKEY"
-        openssl x509 -in distribution_client_cert.pem -noout -text
-        CERT_DATE=$(openssl x509 -in distribution_client_cert.pem -noout -enddate | cut -d= -f 2)
+        # See the development certificate validation above for why this is not plain `openssl`.
+        /usr/bin/openssl pkcs12 -in "$DISTRIBUTION_CERT" -out distribution_client_cert.pem -nokeys -passin "pass:$APPLE_CERTIFICATE_PASSKEY"
+        /usr/bin/openssl x509 -in distribution_client_cert.pem -noout -text
+        CERT_DATE=$(/usr/bin/openssl x509 -in distribution_client_cert.pem -noout -enddate | cut -d= -f 2)
         rm distribution_client_cert.pem
         echo "Distribution certificate expiration date: $CERT_DATE"
         test $(date -j -f '%b %d %H:%M:%S %Y %Z' "$CERT_DATE" '+%s') -gt $(date '+%s')


### PR DESCRIPTION
## Summary

Fixes the `Upload developer IPA to S3` workflow, which has failed on every push to `main` since the macOS-26 runner bump in #307.

The macOS-26 runner image resolves `openssl` to OpenSSL 3.x, while macOS-15 resolved it to the system LibreSSL. Our Apple `.p12` exports are encrypted with RC2-40-CBC, and OpenSSL 3 moved RC2 behind an optional "legacy" provider that is not loaded by default, so the certificate validation steps die with:

```
Error outputting keys and certificates
...error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:
crypto/evp/evp_fetch.c:376:Global default library context, Algorithm (RC2-40-CBC : 0), Properties ()
```

This calls `/usr/bin/openssl` (LibreSSL 3.3.6, which supports RC2) explicitly in both the development and distribution validation steps.

Note that only the *validation* steps were broken. `security import` in the preceding install steps reads RC2 `.p12` files fine, so an expiry-check safety net was taking down the whole pipeline.

### Why not `-legacy`?

Adding `-legacy` to the `pkcs12` calls also works on OpenSSL 3, but LibreSSL rejects that flag entirely — so it would just invert the PATH dependency. An absolute path is deterministic regardless of which `openssl` a future runner image puts first. The most durable fix is re-exporting both `.p12` secrets with AES-256, but that needs a secret rotation and is worth doing separately.

## Blast radius

- `upload-developer-ipa-s3.yml` — currently red on every push to `main`; fixed here.
- `publish.yml` — uses the same composite action and has not run since before the runner bump. **The next release tag would have failed identically.** Also fixed here.
- `ci.yml` and `upload-simulator-saucelabs.yml` — unaffected, neither does certificate signing.

## Test plan

- [x] Confirmed both failing runs ([30112365213](https://github.com/JuulLabs/topaz/actions/runs/30112365213), the first red run, and [31534324623](https://github.com/JuulLabs/topaz/actions/runs/31534324623), the latest) fail at `Validate Development Certificate` with the RC2 error.
- [x] Reproduced locally on macOS 26: reading an RC2-encrypted `.p12` fails with the identical error under OpenSSL 3.6.3 and succeeds under `/usr/bin/openssl`.
- [x] Ran the patched validation step verbatim against a legacy RC2 `.p12`, including the `date -j` expiry comparison — passes with exit 0.
- [x] `action.yml` parses as valid YAML with all 10 steps intact.
- [ ] Confirm `Upload developer IPA to S3` goes green on the merge commit to `main`.

Made with [Cursor](https://cursor.com)